### PR TITLE
fix(tui): recognize TUI profiles and launch them in a PTY terminal window

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for the launcher main window",
-  "windows": ["main"],
+  "description": "Default capability for the launcher windows (main + TUI terminal windows)",
+  "windows": ["main", "tui-*"],
   "permissions": [
     "core:default",
     "core:event:default",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -510,6 +510,55 @@ pub fn list_profiles(state: State<'_, AppState>, home_id: String) -> Result<Vec<
     Ok(out)
 }
 
+/// A profile plus its detected kind (issue #31): `web` profiles run in a
+/// webview window, `tui` profiles run in a PTY terminal window, `other`
+/// profiles are managed as plain processes.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ProfileInfo {
+    pub name: String,
+    /// "web" | "tui" | "other"
+    pub kind: String,
+}
+
+/// Like `list_profiles` but annotated with the profile kind, so the UI can
+/// mark TUI profiles instead of offering a launch path that cannot work.
+#[tauri::command(rename_all = "snake_case")]
+pub fn list_profile_infos(
+    state: State<'_, AppState>,
+    home_id: String,
+) -> Result<Vec<ProfileInfo>, String> {
+    let cfg = state.config.lock().unwrap();
+    let home = cfg
+        .homes
+        .iter()
+        .find(|h| h.id == home_id)
+        .ok_or_else(|| "DSH_HOME 不存在".to_string())?;
+    let profiles_dir = home.path.join("profiles");
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&profiles_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            // Skip the template and non-profile entries.
+            if name == "node_modules" || name == "__temp__" {
+                continue;
+            }
+            if entry.path().is_dir() {
+                let kind = match process::profile_kind(&home.path, &name) {
+                    process::InstanceKind::Web => "web",
+                    process::InstanceKind::Tui => "tui",
+                    process::InstanceKind::Other => "other",
+                };
+                out.push(ProfileInfo {
+                    name,
+                    kind: kind.to_string(),
+                });
+            }
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
 /// Creates a new profile by copying the `__temp__` template inside the
 /// given HOME. Returns the created profile name.
 #[tauri::command(rename_all = "snake_case")]
@@ -787,6 +836,23 @@ pub async fn start_instance(
         }
     }
 
+    // TUI profiles cannot run as piped child processes (the CLI's
+    // interactive-terminal guard refuses pipes, issue #31): they run in a
+    // PTY session instead. Validate the profile kind here and open the
+    // terminal window; the window's frontend then starts the PTY session.
+    if let Ok((home_path, _, _)) = resolve_instance_paths(&state, &id) {
+        if process::profile_kind(&home_path, &profile) == process::InstanceKind::Tui {
+            crate::windows::open_tui_window(&app, &id)?;
+            // Remember the last used profile.
+            let mut cfg = state.config.lock().unwrap();
+            if let Some(inst) = cfg.instances.iter_mut().find(|i| i.id == id) {
+                inst.last_profile = Some(profile);
+            }
+            save_state(&state, &cfg)?;
+            return Ok(());
+        }
+    }
+
     process::start_instance_process(&app, &state, &id, &profile).await?;
     // Remember the last used profile.
     let mut cfg = state.config.lock().unwrap();
@@ -802,6 +868,10 @@ pub async fn stop_instance(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<(), String> {
+    // A TUI instance lives in its own session map, not `state.running`.
+    if state.tui_sessions.lock().await.contains_key(&id) {
+        return crate::tui::stop_tui_session(&app, &state, &id).await;
+    }
     process::stop_instance_process(&app, &state, &id).await
 }
 
@@ -818,6 +888,10 @@ pub async fn open_instance_window(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<(), String> {
+    // TUI instance: reopen its terminal window (issue #31).
+    if state.tui_sessions.lock().await.contains_key(&id) {
+        return crate::windows::open_tui_window(&app, &id);
+    }
     let entry = state.running.lock().await.get(&id).map(|r| r.url.clone());
     let Some(url) = entry.flatten() else {
         return Err("实例未在运行或尚未就绪".to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod skills;
 mod tasks;
 mod terminal;
 mod tray;
+mod tui;
 mod update;
 mod windows;
 mod wsl;
@@ -37,6 +38,10 @@ pub struct AppState {
     pub last_focused_instance: StdMutex<Option<String>>,
     /// Embedded PTY terminal sessions per instance id.
     pub terminals: tokio::sync::Mutex<HashMap<String, terminal::TerminalSession>>,
+    /// PTY-backed TUI instance sessions per instance id (issue #31). Separate
+    /// from `terminals` (the settings-page shell): different lifecycle,
+    /// different status wiring.
+    pub tui_sessions: tokio::sync::Mutex<HashMap<String, tui::TuiSession>>,
 }
 
 /// Extracts a `dsh-launcher://…` deep link from process arguments (Windows
@@ -144,6 +149,7 @@ pub fn run() {
                 profile_locks: tokio::sync::Mutex::new(HashMap::new()),
                 last_focused_instance: StdMutex::new(None),
                 terminals: tokio::sync::Mutex::new(HashMap::new()),
+                tui_sessions: tokio::sync::Mutex::new(HashMap::new()),
             });
 
             // System tray with dynamic menu.
@@ -195,6 +201,7 @@ pub fn run() {
             commands::delete_instance,
             commands::copy_instance,
             commands::list_profiles,
+            commands::list_profile_infos,
             commands::create_profile,
             commands::copy_profile,
             commands::rename_profile,
@@ -246,6 +253,9 @@ pub fn run() {
             terminal::write_terminal_input,
             terminal::resize_terminal_session,
             terminal::close_terminal_session,
+            tui::start_tui_session,
+            tui::write_tui_input,
+            tui::resize_tui_session,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
@@ -256,6 +266,7 @@ pub fn run() {
                 let state = app_handle.state::<AppState>();
                 process::kill_all(&state);
                 terminal::kill_all(&state);
+                tui::kill_all(&state);
             }
         });
 }

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -140,28 +140,69 @@ pub fn build_env(cfg: &Config, instance_id: &str) -> Result<Vec<(String, String)
     Ok(env)
 }
 
-/// Whether a profile is a DSH web application: its package.json
-/// `dsh.profile.bundles` includes `@deepseek-ai/dsh-web-app`. Such profiles
-/// understand `--host/--port` and get a webview; they must bind a random
-/// free port so several instances don't collide.
-fn is_web_profile(home_path: &std::path::Path, profile: &str) -> bool {
+/// Bundle names that classify a profile (issue #31): the web app bundle
+/// drives the webview branch, the TUI bundle requires a real TTY (PTY
+/// branch). A profile bundling both counts as web.
+pub const WEB_BUNDLE: &str = "@deepseek-ai/dsh-web-app";
+pub const TUI_BUNDLE: &str = "@deepseek-harness-tui/dsh-tui";
+
+/// What kind of front end a profile runs, derived from its
+/// `dsh.profile.bundles` (see `profile_kind`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstanceKind {
+    /// Web GUI profile: spawned with piped stdio, status via the `dsh web:`
+    /// URL, displayed in a webview window.
+    Web,
+    /// Terminal UI profile: needs a real TTY, runs inside a PTY session and
+    /// is displayed in an embedded xterm.js window.
+    Tui,
+    /// Anything else: managed purely as a process (legacy behavior).
+    Other,
+}
+
+/// Reads the profile's `dsh.profile.bundles` array, `[]` when unreadable
+/// (missing package.json / malformed JSON).
+fn profile_bundles(home_path: &std::path::Path, profile: &str) -> Vec<String> {
     let pkg = home_path
         .join("profiles")
         .join(profile)
         .join("package.json");
     let Ok(raw) = std::fs::read_to_string(&pkg) else {
-        return false;
+        return Vec::new();
     };
     let Ok(doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
-        return false;
+        return Vec::new();
     };
     doc.pointer("/dsh/profile/bundles")
         .and_then(|b| b.as_array())
         .map(|arr| {
             arr.iter()
-                .any(|b| b.as_str() == Some("@deepseek-ai/dsh-web-app"))
+                .filter_map(|b| b.as_str().map(str::to_string))
+                .collect()
         })
-        .unwrap_or(false)
+        .unwrap_or_default()
+}
+
+/// Classifies a profile by its bundles: web app bundle → `Web` (even when a
+/// TUI bundle is also present — the web front end wins, matching the pre-TUI
+/// behavior), TUI bundle → `Tui`, otherwise `Other`.
+pub fn profile_kind(home_path: &std::path::Path, profile: &str) -> InstanceKind {
+    let bundles = profile_bundles(home_path, profile);
+    if bundles.iter().any(|b| b == WEB_BUNDLE) {
+        InstanceKind::Web
+    } else if bundles.iter().any(|b| b == TUI_BUNDLE) {
+        InstanceKind::Tui
+    } else {
+        InstanceKind::Other
+    }
+}
+
+/// Whether a profile is a DSH web application: its package.json
+/// `dsh.profile.bundles` includes `@deepseek-ai/dsh-web-app`. Such profiles
+/// understand `--host/--port` and get a webview; they must bind a random
+/// free port so several instances don't collide.
+fn is_web_profile(home_path: &std::path::Path, profile: &str) -> bool {
+    profile_kind(home_path, profile) == InstanceKind::Web
 }
 
 /// Whether the installed `dsh-web-app` bundle accepts `--no-open` (added in
@@ -566,13 +607,60 @@ async fn log_line(log: &Arc<Mutex<std::fs::File>>, line: &str) {
     let _ = f.flush();
 }
 
-fn emit_status(app: &AppHandle, status: &InstanceStatus) {
+pub fn emit_status(app: &AppHandle, status: &InstanceStatus) {
     let _ = app.emit(STATUS_EVENT, status);
+}
+
+/// Resolves the profile a TUI session should run: the launcher-passed
+/// `last_profile` when set, else the instance default. TUI windows are only
+/// opened right after `start_instance`, so `last_profile` is authoritative;
+/// the default is a fallback for reattaching after a launcher restart.
+pub fn tui_active_profile(cfg: &Config, instance_id: &str) -> Option<String> {
+    let inst = cfg.instances.iter().find(|i| i.id == instance_id)?;
+    inst.last_profile
+        .clone()
+        .or_else(|| inst.default_profile.clone())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn profile_kind_classifies_web_tui_other() {
+        let dir = std::env::temp_dir().join(format!("dsh-proc-test-{}", uuid::Uuid::new_v4()));
+        let mk = |name: &str, bundles: &str| {
+            let p = dir.join("profiles").join(name);
+            std::fs::create_dir_all(&p).unwrap();
+            std::fs::write(
+                p.join("package.json"),
+                format!(
+                    r#"{{"name":"dsh-profile-{name}","private":true,"dependencies":{{}},"dsh":{{"profile":{{"bundles":{bundles}}}}}}}"#
+                ),
+            )
+            .unwrap();
+        };
+        // Missing package.json -> Other.
+        std::fs::create_dir_all(dir.join("profiles").join("empty")).unwrap();
+        assert_eq!(profile_kind(&dir, "empty"), InstanceKind::Other);
+        // Real-world TUI bundle name (issue #31).
+        mk(
+            "tui",
+            r#"["@deepseek-ai/dsh-base","@deepseek-harness-tui/dsh-tui"]"#,
+        );
+        assert_eq!(profile_kind(&dir, "tui"), InstanceKind::Tui);
+        // Web wins when both bundles are present.
+        mk(
+            "both",
+            r#"["@deepseek-ai/dsh-web-app","@deepseek-harness-tui/dsh-tui"]"#,
+        );
+        assert_eq!(profile_kind(&dir, "both"), InstanceKind::Web);
+        mk("web", r#"["@deepseek-ai/dsh-web-app"]"#);
+        assert_eq!(profile_kind(&dir, "web"), InstanceKind::Web);
+        mk("bot", r#"["@deepseek-ai/dsh-base"]"#);
+        assert_eq!(profile_kind(&dir, "bot"), InstanceKind::Other);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn is_web_profile_detects_web_app_bundle() {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -61,8 +61,9 @@ pub async fn rebuild_tray_menu(app: &AppHandle) {
 async fn running_snapshot(app: &AppHandle) -> Vec<RunningItem> {
     let state = app.state::<AppState>();
     let running = state.running.lock().await;
+    let tui = state.tui_sessions.lock().await;
     let cfg = state.config.lock().unwrap();
-    running
+    let mut items: Vec<RunningItem> = running
         .iter()
         .map(|(id, entry)| {
             let name = cfg
@@ -73,7 +74,21 @@ async fn running_snapshot(app: &AppHandle) -> Vec<RunningItem> {
                 .unwrap_or_else(|| id.clone());
             (id.clone(), name, entry.profile.clone())
         })
-        .collect()
+        .collect();
+    // TUI sessions (issue #31): profile resolved from the instance config.
+    for id in tui.keys() {
+        let Some(profile) = crate::process::tui_active_profile(&cfg, id) else {
+            continue;
+        };
+        let name = cfg
+            .instances
+            .iter()
+            .find(|i| i.id == *id)
+            .map(|i| i.name.clone())
+            .unwrap_or_else(|| id.clone());
+        items.push((id.clone(), name, profile));
+    }
+    items
 }
 
 fn build_menu(app: &AppHandle, running: &[RunningItem]) -> tauri::Result<Menu<tauri::Wry>> {
@@ -139,6 +154,7 @@ fn show_launcher(app: &AppHandle) {
 fn quit(app: &AppHandle) {
     let state = app.state::<AppState>();
     process::kill_all(&state);
+    crate::tui::kill_all(&state);
     app.exit(0);
 }
 
@@ -147,6 +163,11 @@ fn open_instance_from_tray(app: &AppHandle, instance_id: &str) {
     let id = instance_id.to_string();
     tauri::async_runtime::spawn(async move {
         let state = app.state::<AppState>();
+        // TUI instances: reopen the terminal window (issue #31).
+        if state.tui_sessions.lock().await.contains_key(&id) {
+            let _ = crate::windows::open_tui_window(&app, &id);
+            return;
+        }
         let url = state.running.lock().await.get(&id).map(|r| r.url.clone());
         let url = match url {
             Some(Some(u)) => u,
@@ -170,7 +191,12 @@ fn stop_instance_from_tray(app: &AppHandle, instance_id: &str) {
     let id = instance_id.to_string();
     tauri::async_runtime::spawn(async move {
         let state = app.state::<AppState>();
-        let _ = process::stop_instance_process(&app, &state, &id).await;
+        // TUI instances live in their own session map (issue #31).
+        if state.tui_sessions.lock().await.contains_key(&id) {
+            let _ = crate::tui::stop_tui_session(&app, &state, &id).await;
+        } else {
+            let _ = process::stop_instance_process(&app, &state, &id).await;
+        }
     });
 }
 
@@ -179,16 +205,33 @@ fn handle_double_click(app: &AppHandle) {
     tauri::async_runtime::spawn(async move {
         let state = app.state::<AppState>();
         // Prefer the profile page the user focused last; fall back to the
-        // single running instance; otherwise just show the launcher.
+        // single running instance; otherwise just show the launcher. TUI
+        // sessions count as running too (issue #31).
         let last = state.last_focused_instance.lock().unwrap().clone();
         let running = state.running.lock().await;
-        let target_id = last.filter(|id| running.contains_key(id)).or_else(|| {
-            if running.len() == 1 {
-                running.keys().next().cloned()
+        let tui_running = state.tui_sessions.lock().await;
+        let is_running = |id: &str| running.contains_key(id) || tui_running.contains_key(id);
+        let target_id = last.filter(|id| is_running(id)).or_else(|| {
+            let total = running.len() + tui_running.len();
+            if total == 1 {
+                running
+                    .keys()
+                    .next()
+                    .or_else(|| tui_running.keys().next())
+                    .cloned()
             } else {
                 None
             }
         });
+        // TUI first: no URL window, reopen the terminal window.
+        let tui_target = target_id.clone().filter(|id| tui_running.contains_key(id));
+        if let Some(id) = tui_target {
+            drop(tui_running);
+            drop(running);
+            let _ = crate::windows::open_tui_window(&app, &id);
+            return;
+        }
+        drop(tui_running);
         let target = target_id.and_then(|id| {
             let entry = running.get(&id)?;
             let url = entry.url.clone()?;

--- a/src-tauri/src/tui.rs
+++ b/src-tauri/src/tui.rs
@@ -1,0 +1,513 @@
+//! TUI profile sessions: profiles whose `dsh.profile.bundles` contain
+//! `@deepseek-harness-tui/dsh-tui` need a real TTY — the CLI's interactive
+//! terminal guard refuses to start the TUI when stdout/stderr are pipes
+//! (issue #31), so those profiles cannot use the piped `node` process used
+//! by web profiles. Instead they run inside a PTY (ConPTY on Windows) and
+//! the raw output is forwarded to the frontend (`tui://data`) for xterm.js
+//! rendering, mirrored into the instance log.
+//!
+//! Lifecycle differs from web instances:
+//! - `start_instance` (web path) validates and opens the terminal window;
+//!   the window's frontend then calls `start_tui_session` which spawns the
+//!   PTY and registers the instance as Starting.
+//! - The first PTY output flips the instance to Running (a TUI has no URL;
+//!   "alive and producing output" is the running signal).
+//! - Exiting (user `exit`, crash) or a launcher-driven stop tears the
+//!   session down and emits Stopped/Exited like the web path does.
+//! - Closing the terminal window only detaches the view; the instance keeps
+//!   running and reopening the window reattaches to the live output stream.
+
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use serde::Deserialize;
+use std::io::{Read, Write};
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::{Mutex, Notify};
+
+use crate::config::{InstanceState, InstanceStatus};
+use crate::AppState;
+
+pub const DATA_EVENT: &str = "tui://data";
+
+/// Default PTY size until the frontend sends its first resize.
+const DEFAULT_COLS: u16 = 120;
+const DEFAULT_ROWS: u16 = 30;
+
+/// Input for starting / resizing a TUI session.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TuiSessionInput {
+    pub instance_id: String,
+    #[serde(default)]
+    pub cols: Option<u16>,
+    #[serde(default)]
+    pub rows: Option<u16>,
+}
+
+/// Input for writing to a live TUI session.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TuiWriteInput {
+    pub instance_id: String,
+    /// base64 of raw bytes to feed the PTY master.
+    pub data: String,
+}
+
+/// A live PTY-backed TUI session for one instance.
+pub struct TuiSession {
+    /// PTY master: used for resize.
+    pub master: Box<dyn portable_pty::MasterPty + Send>,
+    /// Writable handle to the PTY master (taken once at spawn), shared with
+    /// the reader task.
+    pub writer: Arc<std::sync::Mutex<Box<dyn std::io::Write + Send>>>,
+    /// Killer handle split from the child (portable_pty `clone_killer`): the
+    /// stop path and launcher shutdown kill through it while the waiter's
+    /// blocking task owns the child for `wait()`.
+    pub killer: Arc<Mutex<Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>>>,
+    /// Kill signal: the stop path notifies it, the waiter selects it against
+    /// the child's exit (mirrors `RunningInstance.kill`).
+    pub kill: Arc<Notify>,
+    /// Resolves with the exit code once the child exits; taken once by the
+    /// waiter task. The blocking `wait()` runs on a dedicated thread so the
+    /// async waiter can select it against the kill signal.
+    pub child_waiter:
+        Arc<Mutex<Option<tokio::sync::oneshot::Receiver<Option<i32>>>>>,
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn base64_decode(s: &str) -> Result<Vec<u8>, String> {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD
+        .decode(s)
+        .map_err(|e| format!("输入编码无效: {e}"))
+}
+
+/// Emits an instance status using the shared event so Home / tray / status
+/// surfaces treat TUI instances like any other instance.
+fn emit_instance_status(app: &AppHandle, status: &InstanceStatus) {
+    crate::process::emit_status(app, status);
+}
+
+/// Spawns the instance's DSH CLI inside a fresh PTY and wires the readers
+/// that stream output to the frontend and flip the instance status.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn start_tui_session(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    input: TuiSessionInput,
+) -> Result<(), String> {
+    let instance_id = input.instance_id.as_str();
+    if state.tui_sessions.lock().await.contains_key(instance_id) {
+        return Err("TUI 会话已存在".to_string());
+    }
+    {
+        let running = state.running.lock().await;
+        if running.contains_key(instance_id) {
+            return Err("实例已在运行".to_string());
+        }
+    }
+
+    let (home_path, version_dir) = crate::plugins::resolve_instance(&state, instance_id)?;
+    let cfg = state.config.lock().unwrap().clone();
+    let inst = cfg
+        .instances
+        .iter()
+        .find(|i| i.id == instance_id)
+        .cloned()
+        .ok_or_else(|| "实例不存在".to_string())?;
+    let Some(profile) = crate::process::tui_active_profile(&cfg, instance_id) else {
+        return Err("实例没有可用的 profile".to_string());
+    };
+    // The window only opens for TUI profiles, but re-validate here so a
+    // stale window cannot spawn a non-TUI profile through this path.
+    if crate::process::profile_kind(&home_path, &profile) != crate::process::InstanceKind::Tui {
+        return Err("该实例的 profile 不是 TUI 类型".to_string());
+    }
+
+    if !crate::process::version_bin_ready(&version_dir) {
+        let bin = crate::process::version_bin(&version_dir);
+        return Err(format!(
+            "版本 {} 安装不完整（缺少 {}），请重新安装",
+            cfg.versions
+                .iter()
+                .find(|v| v.dir == version_dir)
+                .map(|v| v.version.clone())
+                .unwrap_or_default(),
+            bin.display()
+        ));
+    }
+
+    let mut env = crate::process::build_env(&cfg, instance_id)?;
+    env.push(("DSH_LAUNCHER_INSTANCE".to_string(), inst.name.clone()));
+
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: input.rows.unwrap_or(DEFAULT_ROWS),
+            cols: input.cols.unwrap_or(DEFAULT_COLS),
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("创建 PTY 失败: {e}"))?;
+
+    let mut cmd = CommandBuilder::new(crate::process::node());
+    cmd.arg(crate::process::version_bin(&version_dir));
+    cmd.arg("--profile");
+    cmd.arg(&profile);
+    cmd.cwd(home_path.as_os_str());
+    for (k, v) in &env {
+        cmd.env(k, v);
+    }
+
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("启动 TUI 进程失败: {e}"))?;
+    // Split a killer handle before the waiter owns the child: the stop path
+    // kills through it without touching the child being waited on.
+    let killer = child.clone_killer();
+    drop(pair.slave); // Close our copy of the slave so EOF propagates.
+
+    // Blocking wait() on a dedicated thread; the async waiter selects the
+    // oneshot against the kill signal.
+    let (wait_tx, child_waiter) = tokio::sync::oneshot::channel::<Option<i32>>();
+    std::thread::spawn(move || {
+        let code = child.wait().ok().map(|st| st.exit_code() as i32);
+        let _ = wait_tx.send(code);
+    });
+
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("获取 PTY 写入通道失败: {e}"))?;
+
+    let session = TuiSession {
+        master: pair.master,
+        writer: Arc::new(std::sync::Mutex::new(writer)),
+        killer: Arc::new(Mutex::new(Some(killer))),
+        kill: Arc::new(Notify::new()),
+        child_waiter: Arc::new(Mutex::new(Some(child_waiter))),
+    };
+
+    // Register before the reader spawns so early input finds the session.
+    state
+        .tui_sessions
+        .lock()
+        .await
+        .insert(instance_id.to_string(), session);
+
+    emit_instance_status(
+        &app,
+        &InstanceStatus {
+            id: instance_id.to_string(),
+            state: InstanceState::Starting,
+            url: None,
+            profile: Some(profile.clone()),
+            exit_code: None,
+        },
+    );
+    crate::log_info!("实例 {instance_id} TUI 会话已启动（profile: {profile}）");
+
+    spawn_reader(&app, &state, instance_id).await?;
+    spawn_waiter(&app, instance_id, &profile).await;
+    Ok(())
+}
+
+/// Reader task: forwards PTY output as `tui://data` events and mirrors it
+/// into the instance log. The first chunk flips the instance to Running
+/// (a TUI has no readiness URL). On EOF the session is torn down: a
+/// user-initiated stop already emitted Stopped (the `stopped` flag makes
+/// this path stay quiet); a natural exit emits Exited with the code.
+async fn spawn_reader(
+    app: &AppHandle,
+    state: &State<'_, AppState>,
+    instance_id: &str,
+) -> Result<(), String> {
+    let (reader, writer) = {
+        let map = state.tui_sessions.lock().await;
+        let session = map
+            .get(instance_id)
+            .ok_or_else(|| "TUI 会话不存在".to_string())?;
+        (
+            session
+                .master
+                .try_clone_reader()
+                .map_err(|e| format!("读取 PTY 失败: {e}"))?,
+            session.writer.clone(),
+        )
+    };
+
+    let app = app.clone();
+    let id = instance_id.to_string();
+    let data_dir = state.data_dir.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let mut reader = reader;
+        let mut buf = [0u8; 8192];
+        let mut running_emitted = false;
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let chunk = &buf[..n];
+                    if !running_emitted {
+                        running_emitted = true;
+                        crate::log_info!("实例 {id} TUI 已就绪");
+                        emit_instance_status(
+                            &app,
+                            &InstanceStatus {
+                                id: id.clone(),
+                                state: InstanceState::Running,
+                                url: None,
+                                profile: None,
+                                exit_code: None,
+                            },
+                        );
+                    }
+                    let _ = app.emit(
+                        DATA_EVENT,
+                        TuiData {
+                            instance_id: id.clone(),
+                            data: base64_encode(chunk),
+                        },
+                    );
+                    append_log(&data_dir, &id, chunk);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+        // EOF (or a dead PTY): flush and detach. Terminal status emission
+        // belongs to the waiter task, which observes the child exit.
+        let _ = writer.lock().map(|mut w| w.flush());
+    });
+    Ok(())
+}
+
+/// Waiter task: owns the exit observation for the TUI session. The child's
+/// blocking `wait()` runs on a dedicated thread; its completion races the
+/// kill signal in a `select!`. Whichever wins tears the session down and
+/// emits the terminal status — the single place TUI instances reach
+/// Stopped/Exited, mirroring the web path's waiter.
+///
+/// This exists because a ConPTY whose child dies abruptly does not
+/// reliably deliver EOF to the master reader; waiting on the child handle
+/// directly is the dependable signal.
+async fn spawn_waiter(app: &AppHandle, instance_id: &str, profile: &str) {
+    let app = app.clone();
+    let id = instance_id.to_string();
+    let profile = profile.to_string();
+
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let (killer_slot, kill, waiter_slot) = {
+            let map = state.tui_sessions.lock().await;
+            let Some(session) = map.get(&id) else {
+                return;
+            };
+            (
+                session.killer.clone(),
+                session.kill.clone(),
+                session.child_waiter.clone(),
+            )
+        };
+        // Only the waiter consumes the child handle for waiting; the stop
+        // path kills through the killer handle.
+        let mut killer = killer_slot.lock().await.take();
+        let child_waiter = waiter_slot.lock().await.take();
+
+        let (exit_code, stopped) = tokio::select! {
+            code = async {
+                match child_waiter {
+                    Some(rx) => rx.await.unwrap_or(None),
+                    None => None,
+                }
+            } => (code, false),
+            _ = kill.notified() => {
+                if let Some(k) = killer.as_mut() {
+                    let _ = k.kill();
+                }
+                (None, true)
+            }
+        };
+
+        state.tui_sessions.lock().await.remove(&id);
+
+        if stopped {
+            crate::log_info!("实例 {id} TUI 已停止（exit code: {exit_code:?}）");
+            let last_profile = state
+                .config
+                .lock()
+                .unwrap()
+                .instances
+                .iter()
+                .find(|i| i.id == id)
+                .and_then(|i| i.last_profile.clone());
+            emit_instance_status(
+                &app,
+                &InstanceStatus {
+                    id,
+                    state: InstanceState::Stopped,
+                    url: None,
+                    profile: last_profile,
+                    exit_code,
+                },
+            );
+        } else {
+            crate::log_warn!("实例 {id} TUI 会话退出（exit code: {exit_code:?}）");
+            emit_instance_status(
+                &app,
+                &InstanceStatus {
+                    id: id.clone(),
+                    state: InstanceState::Exited,
+                    url: None,
+                    profile: Some(profile),
+                    exit_code,
+                },
+            );
+            crate::windows::close_tui_window(&app, &id);
+        }
+        crate::tray::rebuild_tray_menu(&app).await;
+    });
+}
+
+/// Stops a TUI instance: signals the waiter (which kills the PTY child and
+/// emits Stopped). Idempotent — without a live session it still converges
+/// the frontend status, mirroring the web path's stop semantics.
+pub async fn stop_tui_session(
+    app: &AppHandle,
+    state: &State<'_, AppState>,
+    instance_id: &str,
+) -> Result<(), String> {
+    // Notify first, then drop the killer as backup (the waiter takes the
+    // killer before selecting, so either path reaches it).
+    let kill = {
+        let map = state.tui_sessions.lock().await;
+        map.get(instance_id).map(|s| s.kill.clone())
+    };
+    if let Some(kill) = kill {
+        kill.notify_one();
+        return Ok(());
+    }
+    // No live session: still converge the frontend to a terminal state.
+    let profile = state
+        .config
+        .lock()
+        .unwrap()
+        .instances
+        .iter()
+        .find(|i| i.id == instance_id)
+        .and_then(|i| i.last_profile.clone());
+    emit_instance_status(
+        app,
+        &InstanceStatus {
+            id: instance_id.to_string(),
+            state: InstanceState::Stopped,
+            url: None,
+            profile,
+            exit_code: None,
+        },
+    );
+    Ok(())
+}
+
+/// Kills every TUI session (called on launcher exit). Best-effort: notify
+/// the waiter and, as a fallback, kill through the killer handle directly
+/// (the waiter task may not get to run again during shutdown).
+pub fn kill_all(state: &AppState) {
+    let mut map = state.tui_sessions.blocking_lock();
+    for (_, session) in map.drain() {
+        session.kill.notify_one();
+        if let Ok(mut slot) = session.killer.try_lock() {
+            if let Some(mut k) = slot.take() {
+                let _ = k.kill();
+            }
+        }
+    }
+}
+
+/// Appends raw PTY output to the instance log (same file as web instances).
+fn append_log(data_dir: &std::path::Path, instance_id: &str, bytes: &[u8]) {
+    let log_path = data_dir.join("logs").join(format!("{instance_id}.log"));
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        let _ = f.write_all(bytes);
+    }
+}
+
+/// Data event payload: base64 of raw PTY bytes.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TuiData {
+    instance_id: String,
+    data: String,
+}
+
+/// Writes raw input to a live TUI session's PTY master.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn write_tui_input(
+    state: State<'_, AppState>,
+    input: TuiWriteInput,
+) -> Result<(), String> {
+    let bytes = base64_decode(&input.data)?;
+    let map = state.tui_sessions.lock().await;
+    let session = map
+        .get(&input.instance_id)
+        .ok_or_else(|| "TUI 会话不存在".to_string())?;
+    let mut writer = session
+        .writer
+        .lock()
+        .map_err(|_| "TUI 写入通道已锁定".to_string())?;
+    writer
+        .write_all(&bytes)
+        .map_err(|e| format!("写入 TUI 失败: {e}"))?;
+    writer
+        .flush()
+        .map_err(|e| format!("刷新 TUI 写入失败: {e}"))?;
+    Ok(())
+}
+
+/// Resizes a live TUI session's PTY.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn resize_tui_session(
+    state: State<'_, AppState>,
+    input: TuiSessionInput,
+) -> Result<(), String> {
+    let cols = input.cols.unwrap_or(DEFAULT_COLS);
+    let rows = input.rows.unwrap_or(DEFAULT_ROWS);
+    let map = state.tui_sessions.lock().await;
+    let session = map
+        .get(&input.instance_id)
+        .ok_or_else(|| "TUI 会话不存在".to_string())?;
+    session
+        .master
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("调整 TUI 大小失败: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn base64_roundtrip() {
+        let raw = b"\x1b[?25lhello\r\n";
+        let enc = super::base64_encode(raw);
+        assert_eq!(super::base64_decode(&enc).unwrap(), raw);
+    }
+
+    #[test]
+    fn base64_decode_rejects_garbage() {
+        assert!(super::base64_decode("not-base64!").is_err());
+    }
+}

--- a/src-tauri/src/tui.rs
+++ b/src-tauri/src/tui.rs
@@ -70,8 +70,7 @@ pub struct TuiSession {
     /// Resolves with the exit code once the child exits; taken once by the
     /// waiter task. The blocking `wait()` runs on a dedicated thread so the
     /// async waiter can select it against the kill signal.
-    pub child_waiter:
-        Arc<Mutex<Option<tokio::sync::oneshot::Receiver<Option<i32>>>>>,
+    pub child_waiter: Arc<Mutex<Option<tokio::sync::oneshot::Receiver<Option<i32>>>>>,
 }
 
 fn base64_encode(bytes: &[u8]) -> String {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -53,3 +53,60 @@ pub fn close_instance_window(app: &AppHandle, instance_id: &str) {
         let _ = win.close();
     }
 }
+
+/// Opens (or focuses) the terminal window hosting a TUI instance's PTY
+/// session. The window loads the app's own `/terminal/:id` route; its
+/// frontend starts / reattaches the PTY session. Closing the window only
+/// detaches the view — the session keeps running in the background.
+pub fn open_tui_window(app: &AppHandle, instance_id: &str) -> Result<(), String> {
+    let label = format!("tui-{instance_id}");
+    if let Some(win) = app.get_webview_window(&label) {
+        let _ = win.show();
+        let _ = win.unminimize();
+        let _ = win.set_focus();
+        record_focus(app, instance_id);
+        return Ok(());
+    }
+    let name = app
+        .try_state::<AppState>()
+        .and_then(|state| {
+            state
+                .config
+                .lock()
+                .unwrap()
+                .instances
+                .iter()
+                .find(|i| i.id == instance_id)
+                .map(|i| i.name.clone())
+        })
+        .unwrap_or_else(|| instance_id.to_string());
+    // Hash router: the route must arrive in the fragment, or the window
+    // would land on `/` and show the launcher home instead of the terminal.
+    let url = WebviewUrl::App(format!("/index.html#/terminal/{instance_id}").into());
+    let win = WebviewWindowBuilder::new(app, label, url)
+        .title(format!("{name} — DSH TUI"))
+        .inner_size(900.0, 560.0)
+        .min_inner_size(560.0, 320.0)
+        .center()
+        .build()
+        .map_err(|e| e.to_string())?;
+    record_focus(app, instance_id);
+
+    let handle = app.clone();
+    let id = instance_id.to_string();
+    win.on_window_event(move |event| {
+        if let WindowEvent::Focused(true) = event {
+            record_focus(&handle, &id);
+        }
+    });
+    Ok(())
+}
+
+/// Closes a TUI instance's terminal window if it is open (detach only; the
+/// PTY session is owned by the backend, not the window).
+pub fn close_tui_window(app: &AppHandle, instance_id: &str) {
+    let label = format!("tui-{instance_id}");
+    if let Some(win) = app.get_webview_window(&label) {
+        let _ = win.close();
+    }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -141,13 +141,19 @@ async function launchFromDeepLink(u: URL) {
   }
 }
 
-/** Waits for the instance to report `running` with a URL, then opens its window. */
+/** Waits for the instance to report `running` with a URL, then opens its window.
+ * TUI instances (issue #31) run without a URL — the backend already opened
+ * their terminal window in `start_instance`, so reaching running is done. */
 async function openWindowWhenReady(id: string) {
   const deadline = Date.now() + 120_000
   for (;;) {
     const st = store.statusOf(id)
     if (st.state === 'running' && st.url) {
       await api.openInstanceWindow(id)
+      return
+    }
+    if (st.state === 'running' && !st.url) {
+      // TUI: running without a URL; the terminal window is already open.
       return
     }
     if (st.state === 'exited' || Date.now() > deadline) {
@@ -249,7 +255,9 @@ async function onHeaderMouseDown(e: MouseEvent) {
 </script>
 
 <template>
-  <a-layout class="app-shell">
+  <!-- TUI terminal window: bare full-bleed terminal, no app shell. -->
+  <router-view v-if="route.name === 'tui-terminal'" />
+  <a-layout v-else class="app-shell">
     <a-layout-header class="app-header" @mousedown="onHeaderMouseDown">
       <!-- Brand; dragging is handled manually via onHeaderMouseDown. -->
       <div v-if="!onInstancePage" class="app-brand">
@@ -310,7 +318,6 @@ async function onHeaderMouseDown(e: MouseEvent) {
     />
   </a-layout>
 </template>
-
 <style lang="scss" scoped>
 .app-shell {
   height: 100%;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,6 +25,7 @@ import type {
   SkillUpdateInfo,
   PluginChannel,
   PluginVersionPage,
+  ProfileInfo,
   RemoteVersion,
   RuntimeStatus,
   SetPluginsEnabledInput,
@@ -35,6 +36,9 @@ import type {
   TerminalData,
   TerminalIpcInput,
   TerminalStatus,
+  TuiData,
+  TuiSessionInput,
+  TuiWriteInput,
   UninstallPluginInput,
 } from './types'
 
@@ -959,6 +963,22 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
     case 'resize_terminal_session':
     case 'close_terminal_session':
       return undefined as T
+    case 'list_profile_infos': {
+      const homeId = String(args?.home_id ?? '')
+      const home = db.homes.find((h) => h.id === homeId)
+      if (!home) fail('DSH_HOME 不存在')
+      const base: string[] = home.path.endsWith('.dsh') ? ['web', 'demo', 'pack'] : ['web']
+      const names = [...base, ...(mockProfiles[homeId] ?? [])]
+      return names.map((name) => ({
+        name,
+        kind: name.includes('tui') ? ('tui' as const) : ('web' as const),
+      })) as T
+    }
+    case 'start_tui_session':
+      return undefined as T
+    case 'write_tui_input':
+    case 'resize_tui_session':
+      return undefined as T
     case 'start_install_plugin_file_task':
       return 'task-mock-plugin-file' as T
     case 'start_install_plugin_task': {
@@ -1167,6 +1187,21 @@ export const api = {
     }
     terminalStatusListeners.add(cb)
     return () => terminalStatusListeners.delete(cb)
+  },
+
+  // TUI instance sessions (issue #31)
+  listProfileInfos: (homeId: string) => call<ProfileInfo[]>('list_profile_infos', { home_id: homeId }),
+  startTuiSession: (input: TuiSessionInput) => call<void>('start_tui_session', { input }),
+  writeTuiInput: (input: TuiWriteInput) => call<void>('write_tui_input', { input }),
+  resizeTuiSession: (input: TuiSessionInput) => call<void>('resize_tui_session', { input }),
+  async onTuiData(cb: Listener<TuiData>): Promise<() => void> {
+    if (isTauri) {
+      const { listen } = await import('@tauri-apps/api/event')
+      const un = await listen<TuiData>('tui://data', (e) => cb(e.payload))
+      return un
+    }
+    // Browser preview: no live session; nothing to stream.
+    return () => {}
   },
 
   async onInstanceStatus(cb: Listener<InstanceStatus>): Promise<() => void> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -450,3 +450,34 @@ export interface TerminalData {
   instanceId: string
   data: string
 }
+
+// ---------------------------------------------------------------------------
+// TUI instance sessions (issue #31)
+// ---------------------------------------------------------------------------
+
+/** A profile plus its detected kind from `list_profile_infos`. */
+export interface ProfileInfo {
+  name: string
+  /** "web" | "tui" | "other" */
+  kind: 'web' | 'tui' | 'other'
+}
+
+/** Input for starting / resizing a TUI session. */
+export interface TuiSessionInput {
+  instanceId: string
+  cols?: number
+  rows?: number
+}
+
+/** Input for writing to a live TUI session. */
+export interface TuiWriteInput {
+  instanceId: string
+  /** base64 of raw bytes to feed the PTY. */
+  data: string
+}
+
+/** Raw PTY output pushed as `tui://data`. */
+export interface TuiData {
+  instanceId: string
+  data: string
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -30,13 +30,18 @@
       "exited": "Exited"
     },
     "started": "Start command sent",
+    "startedTui": "TUI instance started; terminal window opened",
     "stopped": "Instance stopped",
+    "profileTui": "TUI",
     "health": {
       "prefix": "Dependency check: ",
       "warnTitle": "Dependency tree notice",
       "errorTitle": "Dependency tree fault"
     },
     "noProfile": "No profile available under this instance's DSH_HOME"
+  },
+  "tui": {
+    "starting": "Starting TUI session…"
   },
   "instances": {
     "title": "Instances",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -30,13 +30,18 @@
       "exited": "已退出"
     },
     "started": "实例启动命令已发送",
+    "startedTui": "TUI 实例已启动，终端窗口已打开",
     "stopped": "实例已停止",
+    "profileTui": "TUI",
     "health": {
       "prefix": "依赖自检：",
       "warnTitle": "依赖树提示",
       "errorTitle": "依赖树异常"
     },
     "noProfile": "该实例的 DSH_HOME 下没有可用 Profile"
+  },
+  "tui": {
+    "starting": "正在启动 TUI 会话…"
   },
   "instances": {
     "title": "实例列表",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,6 +24,15 @@ const router = createRouter({
     { path: '/settings', name: 'settings', component: () => import('@/views/Settings.vue') },
     { path: '/tasks', name: 'tasks', component: () => import('@/views/Tasks.vue') },
     { path: '/setup', name: 'setup', component: () => import('@/views/Setup.vue') },
+    // TUI instance terminal: hosted in the dedicated `tui-<id>` window
+    // (issue #31), rendered without the app shell (see App.vue).
+    {
+      path: '/terminal/:instanceId',
+      name: 'tui-terminal',
+      component: () => import('@/views/TuiTerminal.vue'),
+      // Pass the route param straight into the component's instanceId prop.
+      props: true,
+    },
     { path: '/:pathMatch(.*)*', redirect: '/' },
   ],
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -79,6 +79,8 @@ const store = useLauncherStore()
 
 const selectedInstanceId = ref<string | undefined>(store.settings.last_instance_id ?? undefined)
 const profiles = ref<string[]>([])
+/** Kind per profile name ("web" | "tui" | "other") for dropdown badges. */
+const profileKinds = ref<Record<string, string>>({})
 const selectedProfile = ref<string | undefined>(undefined)
 const profilesLoading = ref(false)
 
@@ -111,12 +113,17 @@ const sharedHome = computed(() => {
 
 async function loadProfiles() {
   profiles.value = []
+  profileKinds.value = {}
   selectedProfile.value = undefined
   const inst = selectedInstance.value
   if (!inst) return
   profilesLoading.value = true
   try {
-    profiles.value = await api.listProfiles(inst.home_id)
+    // Issue #31: annotated list so TUI profiles can be labeled in the
+    // dropdown (launching them opens the terminal window, not a webview).
+    const infos = await api.listProfileInfos(inst.home_id)
+    profiles.value = infos.map((p) => p.name)
+    for (const p of infos) profileKinds.value[p.name] = p.kind
     selectedProfile.value =
       (inst.last_profile && profiles.value.includes(inst.last_profile) && inst.last_profile) ||
       (inst.default_profile && profiles.value.includes(inst.default_profile) && inst.default_profile) ||
@@ -269,6 +276,11 @@ const canStart = computed(
     !!store.versionById(selectedInstance.value.version_id),
 )
 
+/** Kind of the currently selected profile ("web" | "tui" | "other"). */
+const selectedProfileKind = computed(
+  () => (selectedProfile.value && profileKinds.value[selectedProfile.value]) || 'other',
+)
+
 const launchSubtitle = computed(() => {
   if (!selectedInstance.value) return ''
   const v = selectedVersion.value?.version ?? '?'
@@ -280,7 +292,13 @@ async function onStart() {
   if (!selectedInstanceId.value || !selectedProfile.value) return
   try {
     await api.startInstance(selectedInstanceId.value, selectedProfile.value)
-    Message.success(t('home.started'))
+    // TUI profiles: start_instance opens the terminal window; the PTY session
+    // is started by that window (issue #31).
+    if (selectedProfileKind.value === 'tui') {
+      Message.success(t('home.startedTui'))
+    } else {
+      Message.success(t('home.started'))
+    }
     // Dependency-tree preflight: advisory only, never blocks the launch. A
     // duplicated core copy in the profile silently breaks every tool call at
     // runtime, so surface it here instead of leaving users to dig through logs.
@@ -392,7 +410,15 @@ function goEditSelected() {
             :disabled="!selectedInstance"
             allow-clear
           >
-            <a-option v-for="p in profiles" :key="p" :value="p">{{ p }}</a-option>
+            <a-option v-for="p in profiles" :key="p" :value="p">
+              <span class="option-line">
+                {{ p }}
+                <a-tag v-if="profileKinds[p] === 'tui'" size="small" color="purple">
+                  {{ t('home.profileTui') }}
+                </a-tag>
+                <a-tag v-else-if="profileKinds[p] === 'web'" size="small" color="green">Web</a-tag>
+              </span>
+            </a-option>
           </a-select>
         </div>
       </div>

--- a/src/views/TuiTerminal.vue
+++ b/src/views/TuiTerminal.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+// Full-page PTY terminal for one TUI instance (issue #31), hosted in the
+// dedicated `tui-<id>` window opened by the backend. Mirrors the xterm.js
+// wiring of TerminalEmbed.vue but drives the TUI session commands
+// (`start_tui_session` / `write_tui_input` / `resize_tui_session`) and the
+// `tui://data` stream.
+//
+// Lifecycle: the backend registered the instance as Starting when
+// `start_instance` opened this window; mounting here spawns the PTY and the
+// first output flips the instance to Running. Closing the window only
+// detaches the view — the session keeps running (stop from Home / tray).
+
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+import { useI18n } from 'vue-i18n'
+import { Message } from '@arco-design/web-vue'
+import { api } from '@/api'
+
+const props = defineProps<{
+  instanceId: string
+}>()
+
+const { t } = useI18n()
+
+const containerRef = ref<HTMLElement | null>(null)
+const starting = ref(false)
+
+let term: Terminal | null = null
+let fitAddon: FitAddon | null = null
+let dataUn: (() => void) | null = null
+let disposed = false
+
+// --- helpers -----------------------------------------------------------------
+
+function b64decode(s: string): string {
+  const bin = atob(s)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return new TextDecoder().decode(bytes)
+}
+
+function b64encode(s: string): string {
+  const bytes = new TextEncoder().encode(s)
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin)
+}
+
+function writeInput(data: string) {
+  api
+    .writeTuiInput({ instanceId: props.instanceId, data: b64encode(data) })
+    .catch((e) => Message.error(String(e)))
+}
+
+// --- session lifecycle -------------------------------------------------------
+
+async function startSession() {
+  if (!term || disposed) return
+  starting.value = true
+  try {
+    await api.startTuiSession({
+      instanceId: props.instanceId,
+      cols: term.cols,
+      rows: term.rows,
+    })
+  } catch (e) {
+    // A live session from a previous window (reattach) reports "already
+    // exists" — that is fine, just keep streaming.
+    const msg = String(e)
+    if (!msg.includes('已存在')) {
+      Message.error(msg)
+      term?.write(`\r\n\x1b[31m${msg}\x1b[0m\r\n`)
+    }
+  } finally {
+    starting.value = false
+  }
+}
+
+function onResize() {
+  if (!term || disposed) return
+  api
+    .resizeTuiSession({ instanceId: props.instanceId, cols: term.cols, rows: term.rows })
+    .catch(() => {
+      /* session may have just exited */
+    })
+}
+
+// --- xterm lifecycle ---------------------------------------------------------
+
+onMounted(async () => {
+  await new Promise((r) => setTimeout(r, 50))
+  if (disposed || !containerRef.value) return
+  const el = containerRef.value
+
+  term = new Terminal({
+    cursorBlink: true,
+    fontSize: 13,
+    fontFamily: 'Consolas, "Courier New", monospace',
+    theme: { background: '#1e1e1e', foreground: '#d4d4d4' },
+    scrollback: 5000,
+  })
+  fitAddon = new FitAddon()
+  term.loadAddon(fitAddon)
+  term.open(el)
+  fitAddon.fit()
+
+  term.onData((d) => writeInput(d))
+
+  dataUn = await api.onTuiData((p) => {
+    if (p.instanceId === props.instanceId && term && !disposed) {
+      term.write(b64decode(p.data))
+    }
+  })
+
+  if (typeof ResizeObserver !== 'undefined') {
+    const ro = new ResizeObserver(() => {
+      if (!fitAddon || !term || disposed) return
+      try {
+        fitAddon.fit()
+        onResize()
+      } catch {
+        /* container hidden */
+      }
+    })
+    ro.observe(el)
+  }
+  window.addEventListener('resize', onResize)
+
+  await startSession()
+})
+
+onBeforeUnmount(() => {
+  disposed = true
+  window.removeEventListener('resize', onResize)
+  dataUn?.()
+  dataUn = null
+  term?.dispose()
+  term = null
+  fitAddon = null
+})
+</script>
+
+<template>
+  <div class="tui-terminal">
+    <div ref="containerRef" class="tui-terminal-box"></div>
+    <div v-if="starting" class="tui-terminal-hint">{{ t('tui.starting') }}</div>
+  </div>
+</template>
+
+<style scoped>
+.tui-terminal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  background: #1e1e1e;
+}
+
+.tui-terminal-box {
+  flex: 1;
+  padding: 6px 8px;
+  min-width: 0;
+}
+
+.tui-terminal-hint {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  color: #86909c;
+  font-size: 12px;
+  pointer-events: none;
+}
+</style>


### PR DESCRIPTION
## TL;DR (EN)

TUI profiles (`dsh.profile.bundles` containing `@deepseek-harness-tui/dsh-tui`) appeared in the profile dropdown but could never start: they were spawned as piped `node` children (`CREATE_NO_WINDOW`), which trips the CLI's interactive-terminal guard, and the `dsh web:` URL regex meant a TUI instance could never reach "Running" (issue #31). This PR launches TUI profiles inside a real PTY and renders them in a dedicated xterm.js terminal window.

## 改动内容

### 后端
- **profile 分类**（`process.rs`）：新增 `InstanceKind { Web, Tui, Other }` 与 `profile_kind()`，按 `dsh.profile.bundles` 判定（TUI bundle 真名为 `@deepseek-harness-tui/dsh-tui`；web/tui bundle 并存时 web 优先，保持既有行为）。`is_web_profile` 改为其包装，行为不变
- **`list_profile_infos` 命令**：在 `list_profiles` 基础上附 kind 标注（原命令不动，零破坏），前端下拉据此给 TUI profile 打紫色徽标
- **TUI 会话**（新 `tui.rs`，portable-pty/ConPTY）：
  - `start_instance` 检测到 TUI profile → 打开 `tui-<id>` 终端窗口（路由 `/terminal/:instanceId`），窗口前端调用 `start_tui_session` 在 PTY 内启动 `node bin.js --profile <name>`（同一套 `build_env` 环境注入）
  - 状态机：spawn → Starting；**首个 PTY 输出 → Running**（TUI 无 URL，存活即运行）；退出 → Stopped/Exited
  - 收尾用 waiter 任务：阻塞 `wait()` 跑在专用线程，与 kill 信号 `select!`（实测 ConPTY 子进程突然死亡时 master reader 不会可靠收到 EOF，等子进程句柄才是可靠信号）；停止路径经 `clone_killer` 分离的 killer 句柄，与 web 路径的 waiter/killer 设计对齐
  - 关闭窗口仅脱附视图，会话继续运行；托盘菜单、停止路径、启动器退出（`kill_all`）均覆盖 TUI 会话
- **capabilities**：`tui-*` 窗口加入 default capability，否则新窗口 invoke/事件全被拒

### 前端
- `TuiTerminal.vue`：全屏 xterm.js 终端（复用 TerminalEmbed 的接线模式），支持重连已有会话
- `Home.vue`：profile 下拉 TUI/Web 徽标；TUI 启动提示语；deep-link 的 `openWindowWhenReady` 兼容无 URL 的 Running 状态
- `App.vue`：终端窗口路由裸渲染（无导航壳）；i18n 双语补全

## 验证

- `cargo clippy --all-targets` 0 警告，`cargo test --lib` 87 passed（含新增 `profile_kind_classifies_web_tui_other`，用真实 bundle 名断言）
- `pnpm build`（vue-tsc）通过
- Windows 11 真实 E2E：注册本机 `~/.dsh` + 源码 checkout 版本 + dsh-tui profile 实例后走 deep-link 启动——实例日志可见真实 TTY 握手（`ESC[6n` DSR 查询等终端序列），TUI 进入启动流程（本机 profile 存在无关的插件配置冲突导致 exit 1，恰好验证了崩溃 → Exited 状态的完整传播链）；托盘、启动器退出清理路径同步接线

## Notes

- Closes #31 的 TUI 部分（issue 的问题 1「本机环境扫描导入」将由后续 PR 处理）
- WSL 内 TUI（PTY 包 wsl.exe）留作后续增强，本次不动 WSL 启动路径
