### PR TITLE
feat(scan): discover and import DSH environments outside the launcher

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod plugins;
 mod process;
 mod proxy;
 mod runtime;
+mod scan;
 mod skills;
 mod tasks;
 mod terminal;
@@ -202,6 +203,10 @@ pub fn run() {
             commands::copy_instance,
             commands::list_profiles,
             commands::list_profile_infos,
+            scan::scan_local_dsh,
+            scan::validate_local_version,
+            scan::import_scanned,
+            scan::detect_external_running,
             commands::create_profile,
             commands::copy_profile,
             commands::rename_profile,

--- a/src-tauri/src/scan.rs
+++ b/src-tauri/src/scan.rs
@@ -1,0 +1,554 @@
+//! Local DSH environment discovery (issue #31, problem 1): the launcher's
+//! instance model used to depend entirely on its own install flow, so DSH
+//! trees that already existed on the machine (source checkouts, npm trees,
+//! extra DSH_HOMEs like `~/.dsh-dev`) were invisible. This module scans for
+//! them and imports the ones the user picks:
+//!
+//! - **Homes**: every `%USERPROFILE%\.dsh*` directory plus the `DSH_HOME`
+//!   environment variable target; each home's `profiles/` entries are
+//!   enumerated and classified (web / tui / other). On Windows, installed
+//!   WSL distros are probed for `~/.dsh*` the same way.
+//! - **Versions**: not scanned from the whole filesystem (too invasive);
+//!   the wizard lets the user add local version directories which are
+//!   validated through the same detection the launcher uses internally
+//!   (`is_repo_checkout` / `version_bin`), for both npm layouts and source
+//!   checkouts. Unbuilt checkouts are reported as "needs build" instead of
+//!   failing the import.
+//! - **External running**: instances with a pinned port that answer a TCP
+//!   connection but were not started by the launcher are reported as
+//!   running externally (see `probe_external_port`).
+
+use crate::config::{paths_equal, DshHome, DshInstance, DshVersion};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use tauri::State;
+
+use crate::AppState;
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+/// A profile found inside a scanned home.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ScannedProfile {
+    pub name: String,
+    /// "web" | "tui" | "other" (same classification as `list_profile_infos`).
+    pub kind: String,
+}
+
+/// A DSH_HOME discovered on the machine.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ScannedHome {
+    /// Home path: a Windows path, or a Linux path inside `wsl`.
+    pub path: PathBuf,
+    /// WSL distro name when the home lives inside a distro.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wsl: Option<String>,
+    /// Profiles found under `<home>/profiles`, sorted by name.
+    pub profiles: Vec<ScannedProfile>,
+    /// A HOME record pointing at this path already exists in the config.
+    pub already_known: bool,
+}
+
+/// A local version directory validated for import (user-picked).
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ScannedVersion {
+    pub dir: PathBuf,
+    /// Best-effort version string from the tree's package.json
+    /// (checkout: `apps/cli`, npm: `node_modules/@deepseek-ai/dsh`).
+    pub version: String,
+    /// "checkout" (source tree) or "npm" (installed package tree).
+    pub layout: String,
+    /// The CLI entry (`version_bin`) exists and is non-empty. Unbuilt
+    /// checkouts are importable but must be built before launching.
+    pub ready: bool,
+    /// A VERSION record pointing at this directory already exists.
+    pub already_known: bool,
+}
+
+/// Full scan report for the import wizard.
+#[derive(Clone, Debug, Default, serde::Serialize)]
+pub struct ScanReport {
+    pub homes: Vec<ScannedHome>,
+    /// Present so the wizard can disable adding it again.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_dsh_home: Option<PathBuf>,
+}
+
+/// Directories under `root` whose name starts with `.dsh` (`.dsh`,
+/// `.dsh-dev`, …), sorted. Pure helper, unit-tested.
+fn dsh_home_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with(".dsh") && entry.path().is_dir() {
+                out.push(entry.path());
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Reads the DSH CLI version string from a version directory: source
+/// checkouts keep the CLI manifest at `apps/cli/package.json`, npm trees at
+/// `node_modules/@deepseek-ai/dsh/package.json`. Falls back to "local".
+fn read_local_version(version_dir: &Path) -> String {
+    let manifest = if is_checkout(version_dir) {
+        version_dir.join("apps").join("cli").join("package.json")
+    } else {
+        version_dir.join("node_modules").join("@deepseek-ai").join("dsh").join("package.json")
+    };
+    read_pkg_version(&manifest).unwrap_or_else(|| "local".to_string())
+}
+
+fn is_checkout(version_dir: &Path) -> bool {
+    version_dir
+        .join("apps")
+        .join("cli")
+        .join("package.json")
+        .exists()
+}
+
+fn read_pkg_version(manifest: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(manifest).ok()?;
+    let doc: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    doc.get("version")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Home display name: the folder's own name (`.dsh`, `.dsh-dev`, …),
+/// suffixed with the distro for WSL homes.
+fn home_display_name(path: &Path, wsl: Option<&str>) -> String {
+    let folder = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+    match wsl {
+        Some(distro) => format!("{folder}（{distro}）"),
+        None => folder,
+    }
+}
+
+/// Scans local DSH environments (homes under `%USERPROFILE%` + `DSH_HOME`
+/// env + WSL distros) and reports what could be imported.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn scan_local_dsh(state: State<'_, AppState>) -> Result<ScanReport, String> {
+    let cfg = state.config.lock().unwrap().clone();
+    let mut report = ScanReport::default();
+
+    // Windows homes: every ~/.dsh* plus the DSH_HOME env target.
+    if let Some(userprofile) = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))
+    {
+        let root = PathBuf::from(userprofile);
+        for path in dsh_home_dirs(&root) {
+            report.homes.push(scan_one_home(&cfg, path, None));
+        }
+    }
+    if let Some(env_home) = std::env::var_os("DSH_HOME") {
+        let path = PathBuf::from(env_home);
+        if path.is_dir() && !report.homes.iter().any(|h| paths_equal(&h.path, &path)) {
+            report.env_dsh_home = Some(path.clone());
+            report.homes.push(scan_one_home(&cfg, path, None));
+        }
+    }
+
+    // WSL homes: probe each installed distro for ~/.dsh* (bounded: distros
+    // are few; each probe is one short-lived wsl.exe call).
+    #[cfg(windows)]
+    for distro in crate::wsl::list_distros() {
+        for (home, profiles) in scan_wsl_homes(&distro) {
+            let path = PathBuf::from(home);
+            if report.homes.iter().any(|h| {
+                h.wsl.as_deref() == Some(distro.as_str()) && paths_equal(&h.path, &path)
+            }) {
+                continue;
+            }
+            let mut scanned = scan_one_home(&cfg, path, Some(distro.clone()));
+            scanned.profiles = profiles
+                .into_iter()
+                .map(|(name, kind)| ScannedProfile { name, kind })
+                .collect();
+            report.homes.push(scanned);
+        }
+    }
+
+    Ok(report)
+}
+
+/// Builds a `ScannedHome` (profile enumeration + kind + known flag) for a
+/// local (non-WSL) home path.
+fn scan_one_home(cfg: &crate::config::Config, path: PathBuf, wsl: Option<String>) -> ScannedHome {
+    let profiles = local_profiles(&path)
+        .into_iter()
+        .map(|(name, kind)| ScannedProfile { name, kind })
+        .collect();
+    ScannedHome {
+        already_known: cfg
+            .homes
+            .iter()
+            .any(|h| paths_equal(&h.path, &path) && h.wsl == wsl),
+        path,
+        wsl,
+        profiles,
+    }
+}
+
+/// Enumerates and classifies the profiles of a local home (skips the
+/// template / node_modules entries, same rules as `list_profiles`).
+fn local_profiles(home_path: &Path) -> Vec<(String, String)> {
+    let profiles_dir = home_path.join("profiles");
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&profiles_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name == "node_modules" || name == "__temp__" || !entry.path().is_dir() {
+                continue;
+            }
+            let kind = match crate::process::profile_kind(home_path, &name) {
+                crate::process::InstanceKind::Web => "web",
+                crate::process::InstanceKind::Tui => "tui",
+                crate::process::InstanceKind::Other => "other",
+            };
+            out.push((name, kind.to_string()));
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// Probes `<distro>` for `~/.dsh*` homes and their profiles. Returns
+/// (home_path, [(profile_name, kind)]) pairs; empty when the distro has no
+/// DSH homes (or wsl.exe is unavailable).
+#[cfg(windows)]
+fn scan_wsl_homes(distro: &str) -> Vec<(String, Vec<(String, String)>)> {
+    // One call lists homes and their profile dirs together; each output
+    // line is either `H<TAB><home>` or `P<TAB><home><TAB><profile>`.
+    let script = r#"for h in "$HOME"/.dsh*; do [ -d "$h" ] || continue; echo "H	$h"; for p in "$h"/profiles/*; do [ -d "$p" ] || continue; echo "P	$h	$(basename "$p")"; done; done"#;
+    let argv = vec!["sh".to_string(), "-c".to_string(), script.to_string()];
+    let out = match tauri::async_runtime::block_on(crate::wsl::wsl_output(distro, &argv)) {
+        Ok(out) => out,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut homes: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    for line in out.lines() {
+        let mut parts = line.split('\t');
+        match (parts.next(), parts.next(), parts.next()) {
+            (Some("H"), Some(home), _) => {
+                let home = home.trim().to_string();
+                if !home.is_empty() && !homes.iter().any(|(h, _)| *h == home) {
+                    homes.push((home, Vec::new()));
+                }
+            }
+            (Some("P"), Some(home), Some(profile)) => {
+                let home = home.trim();
+                let profile = profile.trim();
+                if profile == "node_modules" || profile == "__temp__" {
+                    continue;
+                }
+                if let Some(entry) = homes.iter_mut().find(|(h, _)| h == home) {
+                    entry.1.push((profile.to_string(), String::new()));
+                }
+            }
+            _ => {}
+        }
+    }
+    // Classify WSL profiles through the \\wsl$ UNC share (same filesystem
+    // the web/TUI launch path probes), skipping dirs that vanish there.
+    for (home, profiles) in homes.iter_mut() {
+        let unc = crate::wsl::unc_path(distro, home);
+        profiles.retain(|(name, _)| unc.join("profiles").join(name).exists());
+        for (name, kind) in profiles.iter_mut() {
+            *kind = match crate::process::profile_kind(&unc, name) {
+                crate::process::InstanceKind::Web => "web".to_string(),
+                crate::process::InstanceKind::Tui => "tui".to_string(),
+                crate::process::InstanceKind::Other => "other".to_string(),
+            };
+        }
+    }
+    homes.retain(|(_, profiles)| !profiles.is_empty() || true);
+    homes
+}
+
+/// Validates a user-picked local version directory for import: detects the
+/// layout (checkout vs npm), reads the version string and checks the CLI
+/// entry exists ("ready"). Unknown trees are rejected with a message.
+#[tauri::command(rename_all = "snake_case")]
+pub fn validate_local_version(dir: String) -> Result<ScannedVersion, String> {
+    let path = PathBuf::from(&dir);
+    if !path.is_dir() {
+        return Err("目录不存在".to_string());
+    }
+    let checkout = is_checkout(&path);
+    let npm_manifest = path
+        .join("node_modules")
+        .join("@deepseek-ai")
+        .join("dsh")
+        .join("package.json");
+    if !checkout && !npm_manifest.exists() {
+        return Err(
+            "未识别为 DSH 版本目录（既不是源码 checkout，也没有 node_modules/@deepseek-ai/dsh）"
+                .to_string(),
+        );
+    }
+    let version = read_local_version(&path);
+    let ready = crate::process::version_bin_ready(&path);
+    Ok(ScannedVersion {
+        dir: path,
+        version,
+        layout: if checkout { "checkout" } else { "npm" }.to_string(),
+        ready,
+        already_known: false, // filled by the wizard against the config
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+/// Wizard input: which scanned homes / profiles and which version dirs to
+/// import.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportScannedInput {
+    pub homes: Vec<ImportHomeInput>,
+    pub versions: Vec<ImportVersionInput>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportHomeInput {
+    pub path: String,
+    #[serde(default)]
+    pub wsl: Option<String>,
+    /// Profiles to create instances for (web / tui kinds; "other" profiles
+    /// are importable as plain instances too, user's choice).
+    pub profiles: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportVersionInput {
+    pub dir: String,
+}
+
+/// Import result: what was created vs skipped (already known).
+#[derive(Clone, Debug, Default, serde::Serialize)]
+pub struct ImportReport {
+    pub homes_added: usize,
+    pub versions_added: usize,
+    pub instances_added: usize,
+    pub skipped_known: usize,
+}
+
+/// Imports the user's selection: registers homes / versions and creates one
+/// instance per (home, profile). Idempotent — entries whose path (or
+/// instance name) already exists are skipped and counted.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn import_scanned(
+    state: State<'_, AppState>,
+    input: ImportScannedInput,
+) -> Result<ImportReport, String> {
+    let mut cfg = state.config.lock().unwrap().clone();
+    let mut report = ImportReport::default();
+
+    for dir in &input.versions {
+        let path = PathBuf::from(&dir.dir);
+        if !path.is_dir() {
+            continue;
+        }
+        if cfg.versions.iter().any(|v| paths_equal(&v.dir, &path)) {
+            report.skipped_known += 1;
+            continue;
+        }
+        let version = read_local_version(&path);
+        cfg.versions.push(DshVersion {
+            id: crate::config::new_id("ver"),
+            version,
+            dir: path,
+            wsl: None,
+        });
+        report.versions_added += 1;
+    }
+
+    for home in &input.homes {
+        let path = PathBuf::from(&home.path);
+        if !path.is_dir() && home.wsl.is_none() {
+            continue;
+        }
+        let home_id = match cfg
+            .homes
+            .iter()
+            .find(|h| paths_equal(&h.path, &path) && h.wsl == home.wsl)
+        {
+            Some(existing) => {
+                report.skipped_known += 1;
+                existing.id.clone()
+            }
+            None => {
+                let id = crate::config::new_id("home");
+                cfg.homes.push(DshHome {
+                    id: id.clone(),
+                    name: home_display_name(&path, home.wsl.as_deref()),
+                    path: path.clone(),
+                    wsl: home.wsl.clone(),
+                });
+                report.homes_added += 1;
+                id
+            }
+        };
+        for profile in &home.profiles {
+            // One instance per (home, profile); skip names that exist.
+            let inst_name = format!(
+                "{}·{}",
+                path.file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "DSH".to_string()),
+                profile
+            );
+            if cfg
+                .instances
+                .iter()
+                .any(|i| i.home_id == home_id && i.name == inst_name)
+            {
+                report.skipped_known += 1;
+                continue;
+            }
+            cfg.instances.push(DshInstance {
+                id: crate::config::new_id("inst"),
+                name: inst_name,
+                // Prefer an imported/known version; the instance editor can
+                // repoint it. `None` versions cannot launch until chosen.
+                version_id: cfg
+                    .versions
+                    .first()
+                    .map(|v| v.id.clone())
+                    .unwrap_or_default(),
+                home_id: home_id.clone(),
+                env_overrides: Default::default(),
+                default_profile: Some(profile.clone()),
+                last_profile: None,
+                icon: None,
+                port: None,
+            });
+            report.instances_added += 1;
+        }
+    }
+
+    crate::commands::save_state(&state, &cfg)?;
+    Ok(report)
+}
+
+/// True when `port` on 127.0.0.1 answers a TCP connect within the timeout.
+/// Used to mark launcher-external running instances (issue #31, expectation
+/// 2). Best-effort: a refused/timed-out connect means "not detected".
+pub async fn probe_external_port(port: u16) -> bool {
+    use tokio::net::TcpStream;
+    use tokio::time::{timeout, Duration};
+    timeout(Duration::from_millis(250), async {
+        TcpStream::connect(("127.0.0.1", port)).await.is_ok()
+    })
+    .await
+    .unwrap_or(false)
+}
+
+/// Instances running outside the launcher: pinned-port instances whose port
+/// answers a TCP connect but which are not tracked in `state.running`
+/// (started e.g. via `start-fixed.ps1`). Emitted as Running statuses with
+/// `external: true` so the UI can label them without mixing them into the
+/// launcher's own lifecycle (no stop / open actions).
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ExternalStatus {
+    pub id: String,
+    pub name: String,
+    pub port: u16,
+    pub profile: Option<String>,
+}
+
+/// Detects launcher-external running instances among the pinned-port ones.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn detect_external_running(state: State<'_, AppState>) -> Result<Vec<ExternalStatus>, String> {
+    let cfg = state.config.lock().unwrap().clone();
+    let mut out = Vec::new();
+    for inst in &cfg.instances {
+        let Some(port) = inst.port else { continue };
+        if state.running.lock().await.contains_key(&inst.id) {
+            continue;
+        }
+        if state.tui_sessions.lock().await.contains_key(&inst.id) {
+            continue;
+        }
+        if probe_external_port(port).await {
+            out.push(ExternalStatus {
+                id: inst.id.clone(),
+                name: inst.name.clone(),
+                port,
+                profile: inst.last_profile.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dsh_home_dirs_finds_dsh_prefixed_dirs() {
+        let root = std::env::temp_dir().join(format!("dsh-scan-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(root.join(".dsh")).unwrap();
+        std::fs::create_dir_all(root.join(".dsh-dev")).unwrap();
+        std::fs::create_dir_all(root.join(".dshx")).unwrap();
+        std::fs::create_dir_all(root.join("unrelated")).unwrap();
+        // A file named .dsh-must be ignored (dirs only).
+        std::fs::write(root.join(".dshfile"), "").unwrap();
+        let found = dsh_home_dirs(&root);
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec![".dsh", ".dsh-dev", ".dshx"]);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn read_local_version_prefers_cli_manifest_and_falls_back() {
+        let dir = std::env::temp_dir().join(format!("dsh-scan-{}", uuid::Uuid::new_v4()));
+        // Checkout layout.
+        let cli = dir.join("apps").join("cli");
+        std::fs::create_dir_all(&cli).unwrap();
+        std::fs::write(
+            cli.join("package.json"),
+            r#"{"name":"@deepseek-ai/dsh-cli","version":"9.9.9-test"}"#,
+        )
+        .unwrap();
+        assert_eq!(read_local_version(&dir), "9.9.9-test");
+        // No manifest anywhere -> "local".
+        let empty = std::env::temp_dir().join(format!("dsh-scan-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&empty).unwrap();
+        assert_eq!(read_local_version(&empty), "local");
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&empty).ok();
+    }
+
+    #[test]
+    fn home_display_name_appends_distro() {
+        let p = Path::new("C:\\Users\\x\\.dsh-dev");
+        assert_eq!(home_display_name(p, None), ".dsh-dev");
+        assert_eq!(home_display_name(p, Some("Ubuntu")), ".dsh-dev（Ubuntu）");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_rejects_unknown_dir() {
+        let dir = std::env::temp_dir().join(format!("dsh-scan-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(super::validate_local_version(dir.to_string_lossy().to_string()).is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src-tauri/src/scan.rs
+++ b/src-tauri/src/scan.rs
@@ -99,7 +99,11 @@ fn read_local_version(version_dir: &Path) -> String {
     let manifest = if is_checkout(version_dir) {
         version_dir.join("apps").join("cli").join("package.json")
     } else {
-        version_dir.join("node_modules").join("@deepseek-ai").join("dsh").join("package.json")
+        version_dir
+            .join("node_modules")
+            .join("@deepseek-ai")
+            .join("dsh")
+            .join("package.json")
     };
     read_pkg_version(&manifest).unwrap_or_else(|| "local".to_string())
 }
@@ -160,11 +164,13 @@ pub async fn scan_local_dsh(state: State<'_, AppState>) -> Result<ScanReport, St
     // are few; each probe is one short-lived wsl.exe call).
     #[cfg(windows)]
     for distro in crate::wsl::list_distros() {
-        for (home, profiles) in scan_wsl_homes(&distro) {
+        for (home, profiles) in scan_wsl_homes(&distro).await {
             let path = PathBuf::from(home);
-            if report.homes.iter().any(|h| {
-                h.wsl.as_deref() == Some(distro.as_str()) && paths_equal(&h.path, &path)
-            }) {
+            if report
+                .homes
+                .iter()
+                .any(|h| h.wsl.as_deref() == Some(distro.as_str()) && paths_equal(&h.path, &path))
+            {
                 continue;
             }
             let mut scanned = scan_one_home(&cfg, path, Some(distro.clone()));
@@ -224,12 +230,16 @@ fn local_profiles(home_path: &Path) -> Vec<(String, String)> {
 /// (home_path, [(profile_name, kind)]) pairs; empty when the distro has no
 /// DSH homes (or wsl.exe is unavailable).
 #[cfg(windows)]
-fn scan_wsl_homes(distro: &str) -> Vec<(String, Vec<(String, String)>)> {
+async fn scan_wsl_homes(distro: &str) -> Vec<(String, Vec<(String, String)>)> {
     // One call lists homes and their profile dirs together; each output
     // line is either `H<TAB><home>` or `P<TAB><home><TAB><profile>`.
     let script = r#"for h in "$HOME"/.dsh*; do [ -d "$h" ] || continue; echo "H	$h"; for p in "$h"/profiles/*; do [ -d "$p" ] || continue; echo "P	$h	$(basename "$p")"; done; done"#;
     let argv = vec!["sh".to_string(), "-c".to_string(), script.to_string()];
-    let out = match tauri::async_runtime::block_on(crate::wsl::wsl_output(distro, &argv)) {
+    // `scan_local_dsh` runs on Tauri's tokio runtime, so `wsl_output` must be
+    // awaited rather than driven with `async_runtime::block_on` (which would
+    // panic with "Cannot start a runtime from within a runtime" on any WSL
+    // machine). This was the only non-`.await` `wsl_output` call in the tree.
+    let out = match crate::wsl::wsl_output(distro, &argv).await {
         Ok(out) => out,
         Err(_) => return Vec::new(),
     };
@@ -270,7 +280,7 @@ fn scan_wsl_homes(distro: &str) -> Vec<(String, Vec<(String, String)>)> {
             };
         }
     }
-    homes.retain(|(_, profiles)| !profiles.is_empty() || true);
+    homes.retain(|(_, profiles)| !profiles.is_empty());
     homes
 }
 
@@ -402,12 +412,14 @@ pub async fn import_scanned(
             }
         };
         for profile in &home.profiles {
-            // One instance per (home, profile); skip names that exist.
+            // One instance per (home, profile); skip names that exist. The
+            // name embeds the home display name (which appends the distro for
+            // WSL homes) so a Windows `~/.dsh` and a WSL `~/.dsh` with the
+            // same profile no longer produce the same globally-unique name
+            // (the editor enforces global name uniqueness in create/rename).
             let inst_name = format!(
                 "{}·{}",
-                path.file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| "DSH".to_string()),
+                home_display_name(&path, home.wsl.as_deref()),
                 profile
             );
             if cfg
@@ -471,7 +483,9 @@ pub struct ExternalStatus {
 
 /// Detects launcher-external running instances among the pinned-port ones.
 #[tauri::command(rename_all = "snake_case")]
-pub async fn detect_external_running(state: State<'_, AppState>) -> Result<Vec<ExternalStatus>, String> {
+pub async fn detect_external_running(
+    state: State<'_, AppState>,
+) -> Result<Vec<ExternalStatus>, String> {
     let cfg = state.config.lock().unwrap().clone();
     let mut out = Vec::new();
     for inst in &cfg.instances {

--- a/src-tauri/src/scan.rs
+++ b/src-tauri/src/scan.rs
@@ -552,7 +552,9 @@ mod tests {
 
     #[test]
     fn home_display_name_appends_distro() {
-        let p = Path::new("C:\\Users\\x\\.dsh-dev");
+        // Forward slashes: `Path::file_name` must split the last component on
+        // every CI platform (backslash is a separator only on Windows).
+        let p = Path::new("C:/Users/x/.dsh-dev");
         assert_eq!(home_display_name(p, None), ".dsh-dev");
         assert_eq!(home_display_name(p, Some("Ubuntu")), ".dsh-dev（Ubuntu）");
     }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,8 @@ import type {
   ProfileInfo,
   RemoteVersion,
   RuntimeStatus,
+  ScanReport,
+  ScannedVersion,
   SetPluginsEnabledInput,
   StartTerminalInput,
   TaskInfo,
@@ -40,6 +42,9 @@ import type {
   TuiSessionInput,
   TuiWriteInput,
   UninstallPluginInput,
+  ImportScannedInput,
+  ImportReport,
+  ExternalStatus,
 } from './types'
 
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
@@ -979,6 +984,32 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
     case 'write_tui_input':
     case 'resize_tui_session':
       return undefined as T
+    case 'scan_local_dsh':
+      return {
+        homes: [
+          {
+            path: 'C:\\Users\\Administrator\\.dsh-dev',
+            profiles: [
+              { name: 'web', kind: 'web' },
+              { name: 'dsh-tui', kind: 'tui' },
+            ],
+            alreadyKnown: false,
+          },
+        ],
+        envDshHome: undefined,
+      } as T
+    case 'validate_local_version':
+      return {
+        dir: String(args?.dir ?? ''),
+        version: '0.1.1-rc.2',
+        layout: 'checkout',
+        ready: true,
+        alreadyKnown: false,
+      } as T
+    case 'import_scanned':
+      return { homesAdded: 1, versionsAdded: 0, instancesAdded: 2, skippedKnown: 0 } as T
+    case 'detect_external_running':
+      return [] as T
     case 'start_install_plugin_file_task':
       return 'task-mock-plugin-file' as T
     case 'start_install_plugin_task': {
@@ -1194,6 +1225,12 @@ export const api = {
   startTuiSession: (input: TuiSessionInput) => call<void>('start_tui_session', { input }),
   writeTuiInput: (input: TuiWriteInput) => call<void>('write_tui_input', { input }),
   resizeTuiSession: (input: TuiSessionInput) => call<void>('resize_tui_session', { input }),
+
+  // Local environment scan / import (issue #31)
+  scanLocalDsh: () => call<ScanReport>('scan_local_dsh'),
+  validateLocalVersion: (dir: string) => call<ScannedVersion>('validate_local_version', { dir }),
+  importScanned: (input: ImportScannedInput) => call<ImportReport>('import_scanned', { input }),
+  detectExternalRunning: () => call<ExternalStatus[]>('detect_external_running'),
   async onTuiData(cb: Listener<TuiData>): Promise<() => void> {
     if (isTauri) {
       const { listen } = await import('@tauri-apps/api/event')

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -993,10 +993,10 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
               { name: 'web', kind: 'web' },
               { name: 'dsh-tui', kind: 'tui' },
             ],
-            alreadyKnown: false,
+            already_known: false,
           },
         ],
-        envDshHome: undefined,
+        env_dsh_home: undefined,
       } as T
     case 'validate_local_version':
       return {
@@ -1004,10 +1004,10 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
         version: '0.1.1-rc.2',
         layout: 'checkout',
         ready: true,
-        alreadyKnown: false,
+        already_known: false,
       } as T
     case 'import_scanned':
-      return { homesAdded: 1, versionsAdded: 0, instancesAdded: 2, skippedKnown: 0 } as T
+      return { homes_added: 1, versions_added: 0, instances_added: 2, skipped_known: 0 } as T
     case 'detect_external_running':
       return [] as T
     case 'start_install_plugin_file_task':

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -481,3 +481,64 @@ export interface TuiData {
   instanceId: string
   data: string
 }
+
+// ---------------------------------------------------------------------------
+// Local environment scan / import (issue #31)
+// ---------------------------------------------------------------------------
+
+/** A profile found inside a scanned home. */
+export interface ScannedProfile {
+  name: string
+  kind: 'web' | 'tui' | 'other'
+}
+
+/** A DSH_HOME discovered on the machine. */
+export interface ScannedHome {
+  path: string
+  wsl?: string
+  profiles: ScannedProfile[]
+  alreadyKnown: boolean
+}
+
+/** Full scan report for the import wizard. */
+export interface ScanReport {
+  homes: ScannedHome[]
+  envDshHome?: string
+}
+
+/** A user-picked local version directory, validated. */
+export interface ScannedVersion {
+  dir: string
+  version: string
+  /** "checkout" | "npm" */
+  layout: 'checkout' | 'npm'
+  /** The CLI entry exists (unbuilt checkouts are importable but not launchable). */
+  ready: boolean
+  alreadyKnown: boolean
+}
+
+export interface ImportHomeInput {
+  path: string
+  wsl?: string
+  profiles: string[]
+}
+
+export interface ImportScannedInput {
+  homes: ImportHomeInput[]
+  versions: { dir: string }[]
+}
+
+export interface ImportReport {
+  homesAdded: number
+  versionsAdded: number
+  instancesAdded: number
+  skippedKnown: number
+}
+
+/** An instance running outside the launcher (pinned port answers, not tracked). */
+export interface ExternalStatus {
+  id: string
+  name: string
+  port: number
+  profile: string | null
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -497,13 +497,13 @@ export interface ScannedHome {
   path: string
   wsl?: string
   profiles: ScannedProfile[]
-  alreadyKnown: boolean
+  already_known: boolean
 }
 
 /** Full scan report for the import wizard. */
 export interface ScanReport {
   homes: ScannedHome[]
-  envDshHome?: string
+  env_dsh_home?: string
 }
 
 /** A user-picked local version directory, validated. */
@@ -514,7 +514,7 @@ export interface ScannedVersion {
   layout: 'checkout' | 'npm'
   /** The CLI entry exists (unbuilt checkouts are importable but not launchable). */
   ready: boolean
-  alreadyKnown: boolean
+  already_known: boolean
 }
 
 export interface ImportHomeInput {
@@ -529,10 +529,10 @@ export interface ImportScannedInput {
 }
 
 export interface ImportReport {
-  homesAdded: number
-  versionsAdded: number
-  instancesAdded: number
-  skippedKnown: number
+  homes_added: number
+  versions_added: number
+  instances_added: number
+  skipped_known: number
 }
 
 /** An instance running outside the launcher (pinned port answers, not tracked). */

--- a/src/components/ImportScanDialog.vue
+++ b/src/components/ImportScanDialog.vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+// Import-wizard dialog (issue #31, problem 1): scans the machine for DSH
+// environments the launcher did not install itself — `~/.dsh*` homes
+// (including `DSH_HOME` and WSL distros), plus user-picked local version
+// directories — and imports the user's selection as homes / versions /
+// instances. Idempotent: already-known entries are skipped and reported.
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Message } from '@arco-design/web-vue'
+import { api } from '@/api'
+import type { ImportReport, ScanReport, ScannedVersion } from '@/api/types'
+import { useLauncherStore } from '@/stores/launcher'
+
+const props = defineProps<{
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:visible': [boolean]
+  imported: []
+}>()
+
+const { t } = useI18n()
+const store = useLauncherStore()
+
+const scanning = ref(false)
+const importing = ref(false)
+const report = ref<ScanReport | null>(null)
+/** Selected profile key per home: `${homePath}::${profileName}`. */
+const checkedProfiles = ref<string[]>([])
+const versions = ref<ScannedVersion[]>([])
+const newVersionDir = ref('')
+const importResult = ref<ImportReport | null>(null)
+
+// --- scan --------------------------------------------------------------------
+
+async function runScan() {
+  scanning.value = true
+  importResult.value = null
+  try {
+    report.value = await api.scanLocalDsh()
+    // Default-select web/tui profiles of unknown homes (skip known ones).
+    const defaults: string[] = []
+    for (const home of report.value.homes) {
+      if (home.alreadyKnown) continue
+      for (const p of home.profiles) {
+        if (p.kind !== 'other') defaults.push(`${home.path}::${p.name}`)
+      }
+    }
+    checkedProfiles.value = defaults
+  } catch (e) {
+    Message.error(String(e))
+  } finally {
+    scanning.value = false
+  }
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) void runScan()
+  },
+)
+
+// --- versions ----------------------------------------------------------------
+
+async function addVersion() {
+  const dir = newVersionDir.value.trim()
+  if (!dir) return
+  try {
+    const v = await api.validateLocalVersion(dir)
+    if (versions.value.some((x) => x.dir.toLowerCase() === v.dir.toLowerCase())) {
+      Message.warning(t('importScan.versionAlreadyAdded'))
+      return
+    }
+    versions.value.push(v)
+    newVersionDir.value = ''
+  } catch (e) {
+    Message.error(String(e))
+  }
+}
+
+// --- import ------------------------------------------------------------------
+
+const hasSelection = computed(
+  () => checkedProfiles.value.length > 0 || versions.value.length > 0,
+)
+
+function profileKey(homePath: string, profile: string): string {
+  return `${homePath}::${profile}`
+}
+
+async function doImport() {
+  if (!report.value || !hasSelection.value) return
+  importing.value = true
+  try {
+    const homes = report.value.homes
+      .map((home) => ({
+        path: home.path,
+        wsl: home.wsl,
+        profiles: home.profiles
+          .filter((p) => checkedProfiles.value.includes(profileKey(home.path, p.name)))
+          .map((p) => p.name),
+      }))
+      .filter((h) => h.profiles.length > 0)
+    const result = await api.importScanned({
+      homes,
+      versions: versions.value.map((v) => ({ dir: v.dir })),
+    })
+    importResult.value = result
+    Message.success(t('importScan.done', { instances: result.instancesAdded }))
+    emit('imported')
+    // Reload the store so new instances appear immediately.
+    await store.init()
+  } catch (e) {
+    Message.error(String(e))
+  } finally {
+    importing.value = false
+  }
+}
+
+function close() {
+  emit('update:visible', false)
+}
+</script>
+
+<template>
+  <a-modal
+    :visible="props.visible"
+    :title="t('importScan.title')"
+    :width="640"
+    :footer="false"
+    unmount-on-close
+    @cancel="close"
+  >
+    <a-spin :loading="scanning" style="width: 100%">
+      <div v-if="report" class="scan-body">
+        <p class="scan-hint">{{ t('importScan.hint') }}</p>
+
+        <div v-if="report.homes.length === 0" class="scan-empty">
+          {{ t('importScan.nothingFound') }}
+        </div>
+
+        <div v-for="home in report.homes" :key="home.path" class="home-card">
+          <div class="home-head">
+            <span class="home-path">{{ home.path }}</span>
+            <a-tag v-if="home.wsl" size="small" color="orange">WSL: {{ home.wsl }}</a-tag>
+            <a-tag v-if="home.alreadyKnown" size="small" color="gray">
+              {{ t('importScan.known') }}
+            </a-tag>
+          </div>
+          <a-checkbox-group v-model="checkedProfiles" direction="vertical">
+            <a-checkbox
+              v-for="p in home.profiles"
+              :key="p.name"
+              :value="profileKey(home.path, p.name)"
+              :disabled="home.alreadyKnown"
+            >
+              {{ p.name }}
+              <a-tag v-if="p.kind === 'tui'" size="small" color="purple">TUI</a-tag>
+              <a-tag v-else-if="p.kind === 'web'" size="small" color="green">Web</a-tag>
+            </a-checkbox>
+          </a-checkbox-group>
+        </div>
+
+        <div class="versions-block">
+          <div class="block-title">{{ t('importScan.versions') }}</div>
+          <a-input-search
+            v-model="newVersionDir"
+            :placeholder="t('importScan.versionDirPlaceholder')"
+            search-button
+            :button-text="t('importScan.addVersion')"
+            @search="addVersion"
+          />
+          <div v-for="v in versions" :key="v.dir" class="version-row">
+            <span class="version-dir">{{ v.dir }}</span>
+            <a-tag size="small" color="blue">v{{ v.version }}</a-tag>
+            <a-tag size="small" color="gray">{{ v.layout }}</a-tag>
+            <a-tag v-if="!v.ready" size="small" color="red">{{ t('importScan.needsBuild') }}</a-tag>
+          </div>
+        </div>
+
+        <div v-if="importResult" class="import-result">
+          {{ t('importScan.summary', importResult) }}
+        </div>
+
+        <div class="dialog-actions">
+          <a-button @click="runScan" :loading="scanning">{{ t('importScan.rescan') }}</a-button>
+          <a-button
+            type="primary"
+            :disabled="!hasSelection"
+            :loading="importing"
+            @click="doImport"
+          >
+            {{ t('importScan.import') }}
+          </a-button>
+        </div>
+      </div>
+    </a-spin>
+  </a-modal>
+</template>
+
+<style lang="scss" scoped>
+.scan-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.scan-hint {
+  margin: 0;
+  color: var(--color-text-3);
+  font-size: 12px;
+}
+
+.scan-empty {
+  padding: 24px 0;
+  text-align: center;
+  color: var(--color-text-3);
+}
+
+.home-card {
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-2);
+  border-radius: 8px;
+}
+
+.home-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.home-path {
+  font-weight: 600;
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.versions-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.block-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.version-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.version-dir {
+  word-break: break-all;
+}
+
+.import-result {
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--color-fill-2);
+  font-size: 13px;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/src/components/ImportScanDialog.vue
+++ b/src/components/ImportScanDialog.vue
@@ -42,7 +42,7 @@ async function runScan() {
     // Default-select web/tui profiles of unknown homes (skip known ones).
     const defaults: string[] = []
     for (const home of report.value.homes) {
-      if (home.alreadyKnown) continue
+      if (home.already_known) continue
       for (const p of home.profiles) {
         if (p.kind !== 'other') defaults.push(`${home.path}::${p.name}`)
       }
@@ -108,7 +108,7 @@ async function doImport() {
       versions: versions.value.map((v) => ({ dir: v.dir })),
     })
     importResult.value = result
-    Message.success(t('importScan.done', { instances: result.instancesAdded }))
+    Message.success(t('importScan.done', { instances: result.instances_added }))
     emit('imported')
     // Reload the store so new instances appear immediately.
     await store.init()
@@ -145,7 +145,7 @@ function close() {
           <div class="home-head">
             <span class="home-path">{{ home.path }}</span>
             <a-tag v-if="home.wsl" size="small" color="orange">WSL: {{ home.wsl }}</a-tag>
-            <a-tag v-if="home.alreadyKnown" size="small" color="gray">
+            <a-tag v-if="home.already_known" size="small" color="gray">
               {{ t('importScan.known') }}
             </a-tag>
           </div>
@@ -154,7 +154,7 @@ function close() {
               v-for="p in home.profiles"
               :key="p.name"
               :value="profileKey(home.path, p.name)"
-              :disabled="home.alreadyKnown"
+              :disabled="home.already_known"
             >
               {{ p.name }}
               <a-tag v-if="p.kind === 'tui'" size="small" color="purple">TUI</a-tag>

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1,4 +1,18 @@
 {
+  "importScan": {
+    "title": "Import local DSH environments",
+    "hint": "Scan the machine for DSH environments the launcher did not install (~/.dsh*, the DSH_HOME env var and WSL distros), pick the profiles to import; local DSH version directories can be imported too.",
+    "nothingFound": "No importable DSH environment found",
+    "known": "known",
+    "versions": "Local DSH version directories",
+    "versionDirPlaceholder": "Paste a local DSH version directory (source checkout or npm tree)",
+    "addVersion": "Add",
+    "versionAlreadyAdded": "That version directory is already in the list",
+    "needsBuild": "needs build",
+    "summary": "Import finished: {homesAdded} homes, {versionsAdded} versions, {instancesAdded} instances added; {skippedKnown} already known",
+    "rescan": "Rescan",
+    "import": "Import selected"
+  },
   "app": {
     "title": "DSH Launcher",
     "mockBadge": "Browser preview mode"
@@ -33,6 +47,8 @@
     "startedTui": "TUI instance started; terminal window opened",
     "stopped": "Instance stopped",
     "profileTui": "TUI",
+    "statusExternal": "External",
+    "externalHint": "Something is listening on :{port} for this instance (started outside the launcher)",
     "health": {
       "prefix": "Dependency check: ",
       "warnTitle": "Dependency tree notice",
@@ -149,6 +165,11 @@
   },
   "settings": {
     "title": "Settings",
+    "importScan": {
+      "title": "Import local environments",
+      "hint": "Discover DSH installs that exist outside the launcher (source checkouts, npm trees, ~/.dsh-dev, …) and import them as instances",
+      "open": "Scan & import…"
+    },
     "general": "General",
     "language": "Language",
     "theme": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -9,7 +9,8 @@
     "addVersion": "Add",
     "versionAlreadyAdded": "That version directory is already in the list",
     "needsBuild": "needs build",
-    "summary": "Import finished: {homesAdded} homes, {versionsAdded} versions, {instancesAdded} instances added; {skippedKnown} already known",
+    "summary": "Import finished: {homes_added} homes, {versions_added} versions, {instances_added} instances added; {skipped_known} already known",
+    "done": "Imported {instances} instance(s)",
     "rescan": "Rescan",
     "import": "Import selected"
   },

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,4 +1,18 @@
 {
+  "importScan": {
+    "title": "导入本机 DSH 环境",
+    "hint": "扫描本机已有的 DSH 环境（~/.dsh*、DSH_HOME 环境变量与 WSL 发行版），勾选要导入的 profile；也可添加本地已有的 DSH 版本目录。",
+    "nothingFound": "没有发现可导入的 DSH 环境",
+    "known": "已登记",
+    "versions": "本地 DSH 版本目录",
+    "versionDirPlaceholder": "粘贴本地 DSH 版本目录路径（源码 checkout 或 npm 安装树）",
+    "addVersion": "添加",
+    "versionAlreadyAdded": "该版本目录已在列表中",
+    "needsBuild": "需要先构建",
+    "summary": "导入完成：新增 {homesAdded} 个 HOME、{versionsAdded} 个版本、{instancesAdded} 个实例，跳过 {skippedKnown} 个已存在项",
+    "rescan": "重新扫描",
+    "import": "导入所选"
+  },
   "app": {
     "title": "DSH 启动器",
     "mockBadge": "浏览器预览模式"
@@ -33,6 +47,8 @@
     "startedTui": "TUI 实例已启动，终端窗口已打开",
     "stopped": "实例已停止",
     "profileTui": "TUI",
+    "statusExternal": "外部运行中",
+    "externalHint": "该实例的端口 :{port} 有服务在监听（由启动器之外启动）",
     "health": {
       "prefix": "依赖自检：",
       "warnTitle": "依赖树提示",
@@ -149,6 +165,11 @@
   },
   "settings": {
     "title": "设置",
+    "importScan": {
+      "title": "导入本机环境",
+      "hint": "扫描启动器之外已存在的 DSH 安装（源码 checkout、npm 安装树、~/.dsh-dev 等）并导入为实例",
+      "open": "扫描并导入…"
+    },
     "general": "常规",
     "language": "界面语言",
     "theme": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -9,7 +9,8 @@
     "addVersion": "添加",
     "versionAlreadyAdded": "该版本目录已在列表中",
     "needsBuild": "需要先构建",
-    "summary": "导入完成：新增 {homesAdded} 个 HOME、{versionsAdded} 个版本、{instancesAdded} 个实例，跳过 {skippedKnown} 个已存在项",
+    "summary": "导入完成：新增 {homes_added} 个 HOME、{versions_added} 个版本、{instances_added} 个实例，跳过 {skipped_known} 个已存在项",
+    "done": "已导入 {instances} 个实例",
     "rescan": "重新扫描",
     "import": "导入所选"
   },

--- a/src/stores/launcher.ts
+++ b/src/stores/launcher.ts
@@ -5,6 +5,7 @@ import type {
   DshHome,
   DshInstance,
   DshVersion,
+  ExternalStatus,
   InstanceStatus,
   LauncherSettings,
   MarketPlugin,
@@ -58,6 +59,8 @@ interface LauncherState {
   pluginWizard: PluginWizardState | null
   modpackExport: ModpackExportState | null
   modpackExportMulti: ModpackExportMultiState | null
+  /** Instances running outside the launcher (issue #31): id → info. */
+  externals: Record<string, ExternalStatus>
   loaded: boolean
 }
 
@@ -92,6 +95,7 @@ export const useLauncherStore = defineStore('launcher', {
     pluginWizard: null,
     modpackExport: null,
     modpackExportMulti: null,
+    externals: {},
     loaded: false,
   }),
 
@@ -101,6 +105,8 @@ export const useLauncherStore = defineStore('launcher', {
     instanceById: (s) => (id: string) => s.instances.find((i) => i.id === id),
     statusOf: (s) => (id: string): InstanceStatus =>
       s.statusById[id] ?? { id, state: 'stopped', url: null, profile: null, exit_code: null },
+    /** Info about an externally running instance (issue #31), if detected. */
+    externalOf: (s) => (id: string): ExternalStatus | undefined => s.externals[id],
     taskList: (s) => Object.values(s.tasks).sort((a, b) => b.created_at - a.created_at),
     // A queued task is pending work too, so both counts treat it as active.
     runningTaskCount: (s) =>
@@ -132,15 +138,17 @@ export const useLauncherStore = defineStore('launcher', {
         else pending.push(st)
       })
 
-      const [homes, versions, instances, settings, statuses, tasks, runtime] = await Promise.all([
-        api.listHomes(),
-        api.listVersions(),
-        api.listInstances(),
-        api.getSettings(),
-        api.listInstanceStatus(),
-        api.listTasks(),
-        api.getRuntimeStatus(),
-      ])
+      const [homes, versions, instances, settings, statuses, tasks, runtime, externals] =
+        await Promise.all([
+          api.listHomes(),
+          api.listVersions(),
+          api.listInstances(),
+          api.getSettings(),
+          api.listInstanceStatus(),
+          api.listTasks(),
+          api.getRuntimeStatus(),
+          api.detectExternalRunning(),
+        ])
       this.homes = homes
       this.versions = versions
       this.instances = instances
@@ -148,6 +156,7 @@ export const useLauncherStore = defineStore('launcher', {
       this.statusById = Object.fromEntries(statuses.map((st) => [st.id, st]))
       this.tasks = Object.fromEntries(tasks.map((t) => [t.id, t]))
       this.runtime = runtime
+      this.externals = Object.fromEntries(externals.map((e) => [e.id, e]))
       this.loaded = true
       live = true
       pending.forEach(applyStatus)

--- a/src/stores/launcher.ts
+++ b/src/stores/launcher.ts
@@ -131,6 +131,9 @@ export const useLauncherStore = defineStore('launcher', {
           delete this.statusById[st.id]
         } else {
           this.statusById[st.id] = st
+          // The launcher is now driving this instance, so it is no longer
+          // "running externally" (issue #31): drop a stale external badge.
+          delete this.externals[st.id]
         }
       }
       await api.onInstanceStatus((st) => {

--- a/src/views/Instances.vue
+++ b/src/views/Instances.vue
@@ -167,6 +167,14 @@ async function onOpenWindow(id: string) {
           <a-tag :color="stateColor(store.statusOf(record.id).state)">
             {{ t(`home.status.${store.statusOf(record.id).state}`) }}
           </a-tag>
+          <a-tooltip
+            v-if="store.externalOf(record.id)"
+            :content="t('home.externalHint', { port: store.externalOf(record.id)!.port })"
+          >
+            <a-tag size="small" color="arcoblue">
+              {{ t('home.statusExternal') }} :{{ store.externalOf(record.id)!.port }}
+            </a-tag>
+          </a-tooltip>
           <template v-if="store.statusOf(record.id).url">
             <a-link
               class="status-url"

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -6,9 +6,13 @@ import { api } from '@/api'
 import type { LauncherUpdateInfo, LogLevel, ThemeMode } from '@/api/types'
 import { SUPPORTED_LOCALES } from '@/i18n'
 import { useLauncherStore } from '@/stores/launcher'
+import ImportScanDialog from '@/components/ImportScanDialog.vue'
 
 const { t } = useI18n()
 const store = useLauncherStore()
+
+/** Local-environment import wizard (issue #31). */
+const importScanVisible = ref(false)
 
 const THEME_OPTIONS = computed<{ value: ThemeMode; label: string }[]>(() => [
   { value: 'light', label: t('settings.theme.light') },
@@ -249,6 +253,16 @@ const homeColumns = computed(() => [
   <div class="dl-page">
     <div class="dl-card">
       <div class="dl-card-title">
+        <h3>{{ t('settings.importScan.title') }}</h3>
+      </div>
+      <p class="news-source-hint">{{ t('settings.importScan.hint') }}</p>
+      <a-button type="primary" @click="importScanVisible = true">
+        {{ t('settings.importScan.open') }}
+      </a-button>
+    </div>
+
+    <div class="dl-card">
+      <div class="dl-card-title">
         <h3>{{ t('settings.general') }}</h3>
       </div>
       <a-form :model="store.settings" layout="vertical" class="settings-form">
@@ -467,6 +481,8 @@ const homeColumns = computed(() => [
         </template>
       </a-table>
     </div>
+
+    <ImportScanDialog v-model:visible="importScanVisible" />
   </div>
 </template>
 


### PR DESCRIPTION
## TL;DR (EN)

The launcher's instance model depended entirely on its own install flow: DSH trees that already existed on the machine (source checkouts, npm trees, extra DSH_HOMEs like `~/.dsh-dev`) were invisible, and the user had to re-download DSH to use the launcher at all. External running instances (a web GUI started via `start-fixed.ps1` on :3080) were likewise unknown (issue #31, problem 1). This PR adds a scan → pick → import wizard plus external-running detection.

**Stacked on #33** (base is `fix/31-tui-and-import`; retarget to `main` after that PR merges).

## 改动内容

### 后端（新 `scan.rs`）
- **`scan_local_dsh`**：发现 `%USERPROFILE%\.dsh*`（`.dsh` / `.dsh-dev` / 任意后缀，仅目录）+ `DSH_HOME` 环境变量目标；每个 HOME 枚举 `profiles/` 并按 bundle 分类（web / tui / other，复用 #33 的 `profile_kind`）；已登记的 HOME 标记 `already_known`（幂等对照）。WSL：每个已安装发行版一次 `sh` 调用枚举内部 `~/.dsh*` 与 profiles，分类经 `\\wsl$` UNC 共享判定
- **`validate_local_version`**：用户手选的本地版本目录按启动路径同款检测验证（源码 checkout vs npm 布局），读 package.json 版本号；**未构建的 checkout 标记为 "needs build" 而不是报错拒绝**（真实世界普遍存在半构建的 checkout）
- **`import_scanned`**：幂等导入——homes / versions / 每个 (home, profile) 一个实例；路径或实例名已存在则跳过并计数，返回汇总报告
- **`detect_external_running`**（P1，期望行为 2）：设了固定端口的实例，端口 TCP 探测通但不在启动器跟踪表中 → 前端显示「外部运行中 :端口」徽标（仅提示，不提供停止/打开操作，避免误伤外部进程）

### 前端
- `ImportScanDialog.vue`（Settings 页入口）：扫描 → 勾选 profile（默认选中未知 HOME 的 web/tui）→ 可选添加本地版本目录 → 导入结果汇总；`already_known` 项禁选
- store 增加 `externals` + `externalOf` getter；Instances 列表外部运行徽标
- i18n 双语补全

## 验证

- `cargo clippy --all-targets` 0 警告；`cargo test --lib` 91 passed（+4：`.dsh*` 目录枚举规则、版本号读取回退、HOME 命名、未知目录拒绝）
- `pnpm build`（vue-tsc）通过
- 真实机器验证：本机有 5 个 `~/.dsh*` 目录，扫描预期结果逐目录断言通过（2 个 HOME 各含 web+tui profile 且分类正确；空 HOME 与 `.log` 文件被正确处理/排除）；外部 3080 node 服务在线，端口探测条件成立

## Notes

- Refs #31（两个 PR 合并后该 issue 的三条期望行为全部落地：① 导入向导 ✓ ② 外部运行可见 ✓ ③ TUI 可启动（#33）✓）
- WSL 扫描在本机 Ubuntu 发行版上逻辑可用，但 `\\wsl$` UNC 在发行版未运行时首次访问会触发启动——如维护者认为不妥，可将 WSL 探测改为 opt-in
