### PR TITLE
feat: show a launch-failure dialog with error detail and log tail (issue #30)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1217,6 +1217,58 @@ pub fn open_instance_log(
     reveal_log_file(&app, log_dir.join(format!("{instance_id}.log")))
 }
 
+/// Reads the tail of one instance's runtime log
+/// (`<data_dir>/logs/<instance_id>.log`) so a startup failure can be shown
+/// with its error detail instead of hammering `open_instance_log` (issue
+/// #30). Missing files yield an empty list, never an error.
+#[tauri::command]
+pub fn read_instance_log_tail(
+    state: State<'_, AppState>,
+    instance_id: String,
+    max_lines: Option<usize>,
+) -> Result<Vec<String>, String> {
+    {
+        let cfg = state.config.lock().unwrap();
+        if !cfg.instances.iter().any(|i| i.id == instance_id) {
+            return Err("实例不存在".to_string());
+        }
+    }
+    let log_path = state
+        .data_dir
+        .join("logs")
+        .join(format!("{instance_id}.log"));
+    Ok(read_tail(&log_path, max_lines.unwrap_or(30).min(200)))
+}
+
+/// Reads the last `n` lines of `path`, bounding the read to the final 64 KiB
+/// so a multi-megabyte log does not get slurped in just to show its tail.
+fn read_tail(path: &std::path::Path, n: usize) -> Vec<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let Ok(len) = file.metadata().map(|m| m.len()) else {
+        return Vec::new();
+    };
+    if len == 0 {
+        return Vec::new();
+    }
+    let chunk = len.min(64 * 1024);
+    let mut buf = vec![0u8; chunk as usize];
+    if file.seek(SeekFrom::End(-(chunk as i64))).is_err() || file.read_exact(&mut buf).is_err() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines: Vec<&str> = text.lines().collect();
+    // A trailing newline produces an empty final line; drop it so the tail
+    // ends at the last real line.
+    if lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    let start = lines.len().saturating_sub(n);
+    lines[start..].iter().map(|s| s.to_string()).collect()
+}
+
 /// Opens the DSH_HOME directory of one instance in the file manager.
 #[tauri::command]
 pub fn open_instance_directory(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1535,4 +1535,61 @@ mod tests {
         assert!(!dst.join("broken").exists());
         std::fs::remove_dir_all(&root).ok();
     }
+
+    #[test]
+    fn read_tail_returns_empty_for_missing_or_empty_files() {
+        let root = unique_temp("tail");
+        std::fs::create_dir_all(&root).unwrap();
+        assert!(read_tail(&root.join("missing.log"), 10).is_empty());
+        let empty = root.join("empty.log");
+        std::fs::write(&empty, "").unwrap();
+        assert!(read_tail(&empty, 10).is_empty());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn read_tail_keeps_last_n_lines_and_drops_trailing_newline() {
+        let root = unique_temp("tail");
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("a.log");
+        std::fs::write(&log, "l1\nl2\nl3\nl4\n").unwrap();
+        assert_eq!(read_tail(&log, 2), vec!["l3".to_string(), "l4".to_string()]);
+        // Fewer lines than requested returns everything.
+        assert_eq!(
+            read_tail(&log, 10),
+            vec![
+                "l1".to_string(),
+                "l2".to_string(),
+                "l3".to_string(),
+                "l4".to_string()
+            ]
+        );
+        // No trailing newline still works.
+        std::fs::write(&log, "x\ny").unwrap();
+        assert_eq!(read_tail(&log, 5), vec!["x".to_string(), "y".to_string()]);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn read_tail_bounds_large_files_to_the_last_64kib() {
+        let root = unique_temp("tail");
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("big.log");
+        // 3000 lines × ~40 bytes ≈ 120 KiB — beyond the 64 KiB window.
+        let body: String = (0..3000)
+            .map(|i| format!("line-{i:04}-padding-padding-pad\n"))
+            .collect();
+        std::fs::write(&log, body).unwrap();
+        let tail = read_tail(&log, 3);
+        assert_eq!(tail.len(), 3);
+        assert!(
+            tail.last().unwrap().starts_with("line-2999"),
+            "tail: {tail:?}"
+        );
+        assert!(
+            tail.first().unwrap().starts_with("line-2997"),
+            "tail: {tail:?}"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -221,6 +221,7 @@ pub fn run() {
             commands::open_launcher_directory,
             commands::open_launcher_log,
             commands::open_instance_log,
+            commands::read_instance_log_tail,
             commands::open_instance_directory,
             commands::get_launcher_directory,
             commands::create_launch_shortcut,

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ import { api } from '@/api'
 import { Message } from '@arco-design/web-vue'
 import ModpackImportDialog from '@/components/ModpackImportDialog.vue'
 import PluginFileImportDialog from '@/components/PluginFileImportDialog.vue'
+import InstanceLaunchErrorDialog from '@/components/InstanceLaunchErrorDialog.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -330,6 +331,7 @@ async function onHeaderMouseDown(e: MouseEvent) {
       :file-path="pluginFilePath"
       :initial-instance-id="dropInstanceId"
     />
+    <InstanceLaunchErrorDialog />
   </a-layout>
 </template>
 <style lang="scss" scoped>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -755,10 +755,10 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
     case 'open_instance_log':
     case 'open_instance_directory':
       // Browser preview has no file manager; the target path is reported as-is.
+      return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
     case 'read_instance_log_tail':
       // Browser preview: the mock never writes instance logs; no tail.
       return [] as T
-      return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
     case 'get_launcher_directory':
       return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
     case 'export_modpack': {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -755,6 +755,9 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
     case 'open_instance_log':
     case 'open_instance_directory':
       // Browser preview has no file manager; the target path is reported as-is.
+    case 'read_instance_log_tail':
+      // Browser preview: the mock never writes instance logs; no tail.
+      return [] as T
       return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
     case 'get_launcher_directory':
       return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
@@ -1265,6 +1268,9 @@ export const api = {
   openLauncherLog: () => call<string>('open_launcher_log'),
   /** Reveals one instance's runtime log with the file selected. */
   openInstanceLog: (instanceId: string) => call<string>('open_instance_log', { instanceId }),
+  /** Reads the tail of one instance's runtime log (launch-failure dialog). */
+  readInstanceLogTail: (instanceId: string, maxLines = 30) =>
+    call<string[]>('read_instance_log_tail', { instanceId, maxLines }),
   /** Opens an instance's DSH_HOME directory in the file manager. */
   openInstanceDirectory: (instanceId: string) =>
     call<string>('open_instance_directory', { instanceId }),

--- a/src/components/InstanceLaunchErrorDialog.vue
+++ b/src/components/InstanceLaunchErrorDialog.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Message } from '@arco-design/web-vue'
+import { api } from '@/api'
+import { useLauncherStore } from '@/stores/launcher'
+
+const { t } = useI18n()
+const store = useLauncherStore()
+
+const visible = computed(() => !!store.launchError)
+const instance = computed(() =>
+  store.launchError ? store.instanceById(store.launchError.instanceId) : null,
+)
+
+/** Clipboard payload: summary + tail lines (if any). */
+const summary = computed(() => {
+  const err = store.launchError
+  if (!err) return ''
+  if (err.message) return err.message
+  const name = instance.value?.name ?? err.instanceId
+  if (err.exitCode != null) {
+    return t('launchError.summaryExited', { name, code: err.exitCode })
+  }
+  return t('launchError.summaryDefault', { name })
+})
+
+const tail = ref<string[]>([])
+const tailLoading = ref(false)
+
+watch(
+  visible,
+  async (v) => {
+    if (!v) {
+      tail.value = []
+      return
+    }
+    const err = store.launchError
+    if (!err) return
+    tailLoading.value = true
+    try {
+      tail.value = await api.readInstanceLogTail(err.instanceId, 40)
+    } catch {
+      tail.value = []
+    } finally {
+      tailLoading.value = false
+    }
+  },
+  { immediate: true },
+)
+
+async function copyError() {
+  const text = summary.value + (tail.value.length ? '\n\n' + tail.value.join('\n') : '')
+  try {
+    await navigator.clipboard.writeText(text)
+    Message.success(t('launchError.copied'))
+  } catch {
+    Message.error(t('launchError.copyFailed'))
+  }
+}
+
+async function revealLog() {
+  const err = store.launchError
+  if (!err) return
+  try {
+    await api.openInstanceLog(err.instanceId)
+  } catch (e) {
+    Message.error(String(e))
+  }
+}
+
+function close() {
+  store.dismissLaunchError()
+}
+</script>
+
+<template>
+  <a-modal
+    :visible="visible"
+    :title="t('launchError.title')"
+    :closable="true"
+    @cancel="close"
+  >
+    <template #footer>
+      <a-button @click="copyError">{{ t('launchError.copy') }}</a-button>
+      <a-button @click="revealLog">{{ t('launchError.revealLog') }}</a-button>
+      <a-button type="primary" @click="close">{{ t('launchError.close') }}</a-button>
+    </template>
+
+    <div class="err-body">
+      <a-alert type="error" :message="summary" />
+      <div class="err-tail-title">{{ t('launchError.tailTitle') }}</div>
+      <a-spin :loading="tailLoading" style="width: 100%">
+        <pre v-if="tail.length" class="err-tail">{{ tail.join('\n') }}</pre>
+        <div v-else class="err-tail-empty">{{ t('launchError.tailEmpty') }}</div>
+      </a-spin>
+    </div>
+  </a-modal>
+</template>
+
+<style scoped>
+.err-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.err-tail-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-1);
+}
+
+.err-tail {
+  margin: 0;
+  padding: 10px 12px;
+  max-height: 260px;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--color-text-2);
+  background: var(--color-fill-1);
+  border-radius: 6px;
+}
+
+.err-tail-empty {
+  padding: 14px 12px;
+  font-size: 12px;
+  color: var(--color-text-3);
+  background: var(--color-fill-1);
+  border-radius: 6px;
+}
+</style>

--- a/src/components/InstanceLaunchErrorDialog.vue
+++ b/src/components/InstanceLaunchErrorDialog.vue
@@ -28,22 +28,33 @@ const summary = computed(() => {
 const tail = ref<string[]>([])
 const tailLoading = ref(false)
 
+// Watch the error object itself (not the derived visibility): a second
+// failure while the dialog is still open must refresh summary AND tail.
 watch(
-  visible,
-  async (v) => {
-    if (!v) {
-      tail.value = []
+  () => store.launchError,
+  async (err) => {
+    tail.value = []
+    if (!err) {
+      tailLoading.value = false
       return
     }
-    const err = store.launchError
-    if (!err) return
     tailLoading.value = true
     try {
+      // Flush race: the waiter emits Exited before the stdout/stderr readers
+      // have necessarily written the final crash lines to the log file. Give
+      // them a beat before the first read, then re-read once to catch
+      // late-arriving lines. Bail out if the dialog was dismissed or a newer
+      // error replaced this one meanwhile.
+      await new Promise((r) => setTimeout(r, 350))
+      if (store.launchError !== err) return
+      tail.value = await api.readInstanceLogTail(err.instanceId, 40)
+      await new Promise((r) => setTimeout(r, 800))
+      if (store.launchError !== err) return
       tail.value = await api.readInstanceLogTail(err.instanceId, 40)
     } catch {
       tail.value = []
     } finally {
-      tailLoading.value = false
+      if (store.launchError === err) tailLoading.value = false
     }
   },
   { immediate: true },

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -591,5 +591,17 @@
     "refresh": "Refresh",
     "loading": "Loading…",
     "operationFailed": "Operation failed: {msg}"
+  },
+  "launchError": {
+    "title": "Instance failed to launch",
+    "summaryExited": "Instance \"{name}\" exited unexpectedly after launch (exit code: {code})",
+    "summaryDefault": "Instance \"{name}\" failed to launch",
+    "tailTitle": "Key logs",
+    "tailEmpty": "No log content available (use \"Open full log\" below to view the file)",
+    "copy": "Copy error info",
+    "revealLog": "Open full log",
+    "close": "Close",
+    "copied": "Error info copied",
+    "copyFailed": "Copy failed"
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -591,5 +591,17 @@
     "refresh": "刷新",
     "loading": "加载中…",
     "operationFailed": "操作失败：{msg}"
+  },
+  "launchError": {
+    "title": "实例启动失败",
+    "summaryExited": "实例「{name}」启动后意外退出（exit code: {code}）",
+    "summaryDefault": "实例「{name}」启动失败",
+    "tailTitle": "关键日志",
+    "tailEmpty": "没有可用的日志内容（可点击下方「打开完整日志」查看文件）",
+    "copy": "复制错误信息",
+    "revealLog": "打开完整日志",
+    "close": "关闭",
+    "copied": "错误信息已复制",
+    "copyFailed": "复制失败"
   }
 }

--- a/src/stores/launcher.ts
+++ b/src/stores/launcher.ts
@@ -152,9 +152,13 @@ export const useLauncherStore = defineStore('launcher', {
       const applyStatus = (st: InstanceStatus) => {
         if (st.state === 'stopped' || st.state === 'exited') {
           delete this.statusById[st.id]
-          // Unexpected exit (not a user-initiated stop): surface a dialog
-          // with the error and the log tail (issue #30).
-          if (st.state === 'exited') {
+          // Unexpected FAILURE exit (not a user-initiated stop): surface a
+          // dialog with the error and the log tail (issue #30). A clean exit
+          // (code 0) is a normal shutdown — e.g. typing `exit` in a TUI
+          // terminal — and must not trigger the dialog. A null exit code
+          // means the waiter could not capture it, which is still worth
+          // reporting for the launch-failure use case.
+          if (st.state === 'exited' && st.exit_code !== 0) {
             this.reportLaunchError({ instanceId: st.id, message: '', exitCode: st.exit_code })
           }
         } else {

--- a/src/stores/launcher.ts
+++ b/src/stores/launcher.ts
@@ -74,6 +74,8 @@ interface LauncherState {
   /** Incremented whenever a background task is queued from a page that
    * stays put; App.vue plays the fly-to-tasks animation on change. */
   taskFlyTick: number
+  /** Last failed launch (sync error or unexpected exit) for the error dialog. */
+  launchError: { instanceId: string; message: string; exitCode: number | null } | null
   loaded: boolean
 }
 
@@ -116,6 +118,7 @@ export const useLauncherStore = defineStore('launcher', {
     externals: {},
     homeProfile: null,
     taskFlyTick: 0,
+    launchError: null,
     loaded: false,
   }),
 
@@ -149,6 +152,11 @@ export const useLauncherStore = defineStore('launcher', {
       const applyStatus = (st: InstanceStatus) => {
         if (st.state === 'stopped' || st.state === 'exited') {
           delete this.statusById[st.id]
+          // Unexpected exit (not a user-initiated stop): surface a dialog
+          // with the error and the log tail (issue #30).
+          if (st.state === 'exited') {
+            this.reportLaunchError({ instanceId: st.id, message: '', exitCode: st.exit_code })
+          }
         } else {
           this.statusById[st.id] = st
           // The launcher is now driving this instance, so it is no longer
@@ -299,6 +307,14 @@ export const useLauncherStore = defineStore('launcher', {
       } finally {
         this.marketLoading = false
       }
+    },
+
+    /** Opens the launch-failure dialog (sync error or unexpected exit). */
+    reportLaunchError(payload: { instanceId: string; message: string; exitCode: number | null }) {
+      this.launchError = payload
+    },
+    dismissLaunchError() {
+      this.launchError = null
     },
   },
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -316,15 +316,12 @@ async function onStart() {
   } catch (e) {
     // Sync failure (preflight / spawn): surface the full detail in the
     // launch-failure dialog instead of a transient toast (issue #30).
-    if (selectedInstanceId.value) {
-      store.reportLaunchError({
-        instanceId: selectedInstanceId.value,
-        message: String(e),
-        exitCode: null,
-      })
-    } else {
-      Message.error(String(e))
-    }
+    // (onStart early-returns without a selection, so an id always exists here.)
+    store.reportLaunchError({
+      instanceId: selectedInstanceId.value,
+      message: String(e),
+      exitCode: null,
+    })
   }
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -314,7 +314,17 @@ async function onStart() {
     // runtime, so surface it here instead of leaving users to dig through logs.
     void reportHealth(selectedInstanceId.value, selectedProfile.value)
   } catch (e) {
-    Message.error(String(e))
+    // Sync failure (preflight / spawn): surface the full detail in the
+    // launch-failure dialog instead of a transient toast (issue #30).
+    if (selectedInstanceId.value) {
+      store.reportLaunchError({
+        instanceId: selectedInstanceId.value,
+        message: String(e),
+        exitCode: null,
+      })
+    } else {
+      Message.error(String(e))
+    }
   }
 }
 


### PR DESCRIPTION
Closes #30

## 问题 / Problem

启动实例失败时,主页只显示一条短暂的 `Message.error` 提示,用户无法从提示中获得具体原因,必须手动打开 `logs/<实例id>.log` 排查——对非技术用户极不友好。

## 改动 / What changed

**后端 (Rust)**
- 新增 `read_instance_log_tail` 命令:读取实例运行日志尾部(最多 200 行,读取范围限制在文件末尾 64 KiB),缺失文件返回空而非报错;已注册进 invoke handler 与浏览器预览 mock。

**前端 (Vue/TS)**
- store(`launcher.ts`):`exited` 事件(非用户主动 `stopped`)现在会记录 `launchError`(含 exit code),不再静默丢弃状态。
- 新增 `InstanceLaunchErrorDialog` 组件:标题「实例启动失败」,展示错误摘要 + 关键日志尾部,底部操作「复制错误信息 / 打开完整日志 / 关闭」。
- `Home.vue`:同步启动失败(前置校验 / spawn 失败)同样接入该对话框。
- `App.vue` 挂载对话框;`api/index.ts` 封装 `readInstanceLogTail`;i18n 中英文案齐全。

## 验证 / Validation(与 CI 相同命令)

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅(91 passed)
- `pnpm build`(vue-tsc + vite)✅
- `node ci/check-versions.mjs` ✅
- `node --test ci/release-notes.test.mjs` / `bump-version.test.mjs` ✅