### PR TITLE
fix(plugins): 插件市场进入安装向导后返回时保留搜索、筛选与滚动位置

### DIFF
--- a/src/composables/download-scroll.ts
+++ b/src/composables/download-scroll.ts
@@ -1,0 +1,20 @@
+import { inject, provide } from 'vue'
+
+/** Scope key used by the download pages' shared scrollbar accessor. */
+const DOWNLOAD_SCROLL_KEY = Symbol('download-scroll')
+
+/**
+ * Callback that reads the current scrollTop of the shared download scrollbar
+ * OR sets it to a given pixel offset. The child views (e.g. the plugin market)
+ * use this to persist/restore their scroll position across navigations.
+ */
+export type DownloadScrollAccessor = (top: number | null) => number | void
+
+/** Provided by Download.vue; other pages consume it via injectDownloadScroll. */
+export function provideDownloadScroll(accessor: DownloadScrollAccessor) {
+  provide(DOWNLOAD_SCROLL_KEY, accessor)
+}
+
+export function injectDownloadScroll(): DownloadScrollAccessor | null {
+  return inject<DownloadScrollAccessor | null>(DOWNLOAD_SCROLL_KEY, null)
+}

--- a/src/stores/launcher.ts
+++ b/src/stores/launcher.ts
@@ -9,6 +9,7 @@ import type {
   LauncherSettings,
   MarketPlugin,
   PluginChannel,
+  PluginSource,
   PluginVersionInfo,
   RemoteVersion,
   RuntimeStatus,
@@ -55,6 +56,12 @@ interface LauncherState {
   marketPlugins: MarketPlugin[]
   marketLoading: boolean
   marketLoadedAt: number | null
+  /** Search box of the plugin market page, persisted across navigations. */
+  pluginMarketSearch: string
+  /** Source filter ('' | 'dsh-plugins' | 'awesome-dsh-plugin') of the market page. */
+  pluginMarketSource: PluginSource | ''
+  /** Scroll offset of the plugin market page's scrollbar, in px. */
+  pluginMarketScrollTop: number
   pluginWizard: PluginWizardState | null
   modpackExport: ModpackExportState | null
   modpackExportMulti: ModpackExportMultiState | null
@@ -89,6 +96,9 @@ export const useLauncherStore = defineStore('launcher', {
     marketPlugins: [],
     marketLoading: false,
     marketLoadedAt: null,
+    pluginMarketSearch: '',
+    pluginMarketSource: '' as PluginSource | '',
+    pluginMarketScrollTop: 0,
     pluginWizard: null,
     modpackExport: null,
     modpackExportMulti: null,

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -1,13 +1,32 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useLauncherStore } from '@/stores/launcher'
+import { provideDownloadScroll } from '@/composables/download-scroll'
+import type { ScrollbarInstance } from '@arco-design/web-vue'
 
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const store = useLauncherStore()
+
+const scrollbar = ref<ScrollbarInstance | null>(null)
+
+/**
+ * Read (top === null) or write the shared scrollbar's scrollTop. The scrollable
+ * element is .arco-scrollbar-container: the template style (`overflow-y: auto`)
+ * is forwarded there via $attrs rather than onto the root .arco-scrollbar.
+ */
+function scrollAccessor(top: number | null): number | void {
+  if (top === null) {
+    const el = scrollbar.value?.$el?.querySelector('.arco-scrollbar-container')
+    return el ? (el as HTMLElement).scrollTop : 0
+  }
+  scrollbar.value?.scrollTop(top)
+}
+
+provideDownloadScroll(scrollAccessor)
 
 const selectedKeys = computed(() => {
   const name = route.name as string
@@ -49,7 +68,12 @@ function onRefreshVersions() {
       </a-menu>
     </aside>
     <section class="download-content">
-      <a-scrollbar type="track" outer-style="height: 100%" style="height: 100%; overflow-y: auto">
+      <a-scrollbar
+        ref="scrollbar"
+        type="track"
+        outer-style="height: 100%"
+        style="height: 100%; overflow-y: auto"
+      >
         <div class="download-inner">
           <router-view />
         </div>

--- a/src/views/plugins/Market.vue
+++ b/src/views/plugins/Market.vue
@@ -1,19 +1,28 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useLauncherStore } from '@/stores/launcher'
+import { injectDownloadScroll } from '@/composables/download-scroll'
 import { api } from '@/api'
 import type { MarketPlugin, PluginSource } from '@/api/types'
 
 const router = useRouter()
 const { t } = useI18n()
 const store = useLauncherStore()
+const scrollAccessor = injectDownloadScroll()
 
-const search = ref('')
+const search = ref(store.pluginMarketSearch)
 const error = ref<string | null>(null)
 /** '' means "all sources". */
-const sourceFilter = ref<'' | PluginSource>('')
+const sourceFilter = ref<'' | PluginSource>(store.pluginMarketSource)
+
+// Persist the search box + source filter in the store so they survive a trip
+// into the install wizard and back (issue #29).
+watch([search, sourceFilter], ([q, src]) => {
+  store.pluginMarketSearch = q
+  store.pluginMarketSource = src
+})
 
 function pickDescription(p: MarketPlugin): string {
   const d = p.description
@@ -73,6 +82,18 @@ async function load() {
 
 onMounted(() => {
   if (store.marketPlugins.length === 0) load()
+  // Restore the saved scroll offset once the list has re-rendered.
+  nextTick(() => {
+    if (store.pluginMarketScrollTop > 0) {
+      scrollAccessor?.(store.pluginMarketScrollTop)
+    }
+  })
+})
+
+onBeforeUnmount(() => {
+  // Remember where the user was scrolled for the next visit.
+  const top = (scrollAccessor?.(null) as number) ?? 0
+  store.pluginMarketScrollTop = top
 })
 </script>
 


### PR DESCRIPTION
Close #29

## 问题

在插件市场页面使用搜索框筛选插件后,点击某个插件进入安装向导(版本选择 → 实例/Profile),随后返回时页面重置为初始状态:搜索框清空、来源筛选丢失、滚动位置回顶。用户需要重新输入搜索条件并从头翻找。

## 根因

- 搜索框与来源筛选是 `Market.vue` 组件内的局部 `ref`,没有任何持久化;
- 返回路径(`VersionPick.vue` / `InstallWizard.vue`)会重新挂载 `Market.vue`,局部状态随之复位;
- 无 keep-alive、无 `scrollBehavior`,且滚动发生在 `Download.vue` 的共享 `a-scrollbar` 容器内,浏览器默认恢复也覆盖不到。

## 改动

- **`stores/launcher.ts`**:新增 `pluginMarketSearch` / `pluginMarketSource` / `pluginMarketScrollTop` 三个持久化字段。
- **`src/composables/download-scroll.ts`(新)**:provide/inject 型滚动访问器,让子页面可读写 `Download.vue` 共享 scrollbar 的 `scrollTop`。
- **`Market.vue`**:搜索/筛选初值取自 store 并双向写回;挂载时恢复保存的滚动位置,卸载时回存。
- **`Download.vue`**:向子页面 provide 滚动访问器。

插件目录数据本身缓存在 Pinia store,不用重载;此处只恢复「视图状态」。此改动不触碰增减插件的 Rust/后端逻辑,纯前端 UI 状态保留。