### PR TITLE
feat: 支持修改启动器数据目录位置(issue #43)

### DIFF
--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -228,13 +228,12 @@ settings.dataDir.rollback         恢复上一数据目录
 
 - 目标:实现启动自举 + 迁移状态机,Rust 侧全部完成
 - 轮次拆解:
-  - 轮 2a(worker):`data_dir` 解析改为 `resolve_data_dir(app)`(env→指针→默认),
-    `AppState` 增加 `source: DataDirSource`;新增 `migrate.rs` 状态机骨架
-  - 轮 2a 后(oracle):审查状态机边界条件(失败回滚、`.old-<ts>` 快照、标记文件)
-  - 轮 2b(worker):完整迁移实现(复制/校验/切换/清理/回滚)+ 三个新命令
-  - 轮 2c(worker,如有遗漏):边缘处理(无 network drive、目标已有文件、权限拒绝,
-    处理 `ensure_local_node_on_path` 的自举顺序副作用)
-  - 轮 2d(reviewer):全量 review,must pass `cargo check`
+  - [x] 轮 2a:完成 `migrate.rs` 状态机 + `bootstrap(app)` 自举(env→指针→默认),
+    `AppState` 增加 `data_dir_source` + `data_dir_notice`
+  - [x] 轮 2a 后:状态机边界审定(失败回滚、`.old-<ts>` 快照、标记文件、指针存活)
+  - [x] 轮 2b:完整迁移实现(复制/校验/切换/快照/回滚)+ `pick_data_dir` / `commit_data_dir` / `get_data_dir_source`
+  - [x] 轮 2c:边缘处理(目标已有文件、权限拒绝、env 分支不迁移、启动时断点清理)
+  - [x] 轮 2d:全量 review,`cargo check` + 4 单元测试通过
 - 交付:`resolve_data_dir` + `migrate.rs` + 3 命令;验收人:reviewer
 
 ### 阶段 3:UI 与 i18n(1 轮 worker + review)
@@ -298,3 +297,4 @@ settings.dataDir.rollback         恢复上一数据目录
 
 | 0 | 现状确认 | scout(主 agent) | 基线 3a802ae 无数据目录改动;行号修正;dialog 插件已在 | ✅ 完成 |
 | 1 | 设计定稿 | oracle/reviewer(主 agent 替代) | 命令签名、迁移状态机终稿、i18n 键位、UI 裁定 | ✅ 完成 |
+| 2 | 迁移引擎 | worker(主 agent) | migrate.rs + bootstrap + 3 命令;cargo check 零告警、4 测试通过 | ✅ 完成 |

--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -1,0 +1,241 @@
+# Issue #43 任务树 — 支持修改启动器数据目录位置
+
+> 来源:<https://github.com/dsh-plugins/dsh-launcher/issues/43>
+> 核验基线:`origin/main` @ `3a802ae`(2026-09 之后无相关改动)
+> 文档状态:draft v1。本文件既是规划文档,也是执行时回填进度的活文档。
+
+---
+
+## 0. 结论先行
+
+| 项 | 结论 |
+| --- | --- |
+| 问题是否真实存在 | ✅ 真实。`lib.rs:121` 硬编码 `app.path().app_data_dir()`,数据目录固定为 `%APPDATA%\in.dsh-plug.dsh-launcher`,无可配置覆盖机制;设置页仅有查看按钮 |
+| 是否可做 | ✅ 可行,但**不能运行中热迁移**,必须走「写入新位置 → 重启 → 启动迁移」流程 |
+| 主要风险 | 鸡生蛋(新位置存哪)、日志句柄占用、versions/homes 被运行实例占用、deep-link/单实例/托盘的自举顺序 |
+| 建议总迭代 | 6 个阶段,约 **8~11 轮 agent 迭代**(其中阶段 2 迁移引擎是核心) |
+
+---
+
+## 1. 源码核验明细(证据)
+
+### 1.1 数据目录的固定方式
+
+- `src-tauri/src/lib.rs:121` — `let data_dir = app.path().app_data_dir()?;`
+  - Tauri 2 在 Windows 上解析为 `%APPDATA%\{identifier}`,identifier 见 `tauri.conf.json`:`in.dsh-plug.dsh-launcher`
+  - 写入 `AppState { data_dir, config_path, ... }` 后全程不可变
+- 全仓库 `data_dir` 引用 **48 处**,核心消费方:
+  - `config.json`:`lib.rs:126` + `config::load_config`
+  - `logs/latest.log`:`applog::init`(`applog.rs:56`,`lib.rs:134`)持有**文件句柄**
+  - `versions/<version>`:`tasks.rs:929,1078`(安装/删除版本)
+  - `homes/<name>`(专属 HOME 默认路径):`commands.rs:72 default_dedicated_home_path`
+  - `.pnpm-store`:`tasks.rs:931,1081`、`plugins.rs:1633,1859`、`modpack.rs:1412`
+  - `tools/node`(managed node,issue #23):`runtime.rs:56,401,415`
+  - `icons/`:`commands.rs:1280`;运行日志:`process.rs:384`、`tui.rs:245`、`terminal.rs:154`
+
+> **阶段 0 复核修正(2026-09 基线 `3a802ae`)**:以下行号为实际值,原文编号仅作参考。
+> - `lib.rs:122` `let data_dir = app.path().app_data_dir()?;`,`lib.rs:123` create_dir_all、`:126` ensure_local_node_on_path、`:127` config_path、`:135` applog::init、`:146` 写入 AppState
+> - `tasks.rs:960,1109`(`versions/<version>` 安装/删除)、`tasks.rs:962,1112`(`.pnpm-store`)、`tasks.rs:1298`(tools)
+> - `plugins.rs:2051,2277`(`.pnpm-store`)、`modpack.rs:1483`(`.pnpm-store`)
+> - `runtime.rs:57` `local_node_dir`、`runtime.rs:402` tools、`runtime.rs:416` local_node_dir
+> - `commands.rs:77` homes、`commands.rs:426` data_dir、`commands.rs:1025` get_launcher_directory、`commands.rs:1179` open_launcher_directory、`commands.rs:1192` open_launcher_log、`commands.rs:1196,1215` logs、`commands.rs:1382` icons
+> - `process.rs:384`、`tui.rs:434`、`terminal.rs:154`(`data_dir.join("bin")`/logs)
+> - `AppState.data_dir` 写后不可变(仅在 setup 赋值),全部消费方约 27 处 `state.data_dir` + 各处形参传递
+> - 依赖:`tauri-plugin-dialog = "2"`(Cargo.toml:16)已在;`walkdir`/`fs_extra` **未引入**,迁移复制用 std::fs 递归即可(阶段 2 确认)
+> - UI:`Settings.vue:479-484` 数据目录卡片;`api/index.ts:754-763,1326-1330` 命令映射;`zh-CN.json:279`/`en-US.json:279` `dataDir`
+> - `invoke_handler` 注册点 `lib.rs:182`;single_instance `lib.rs:64`、deep-link `lib.rs:88`、托盘 `lib.rs:158`
+
+### 1.2 现有 UI / 命令状态
+
+- `Settings.vue:435-443`:「数据目录」卡片 = 路径展示 + `打开目录` + `查看日志` 两个按钮
+- 命令:`get_launcher_directory`(commands.rs:920)、`open_launcher_directory`(commands.rs:1075)、`open_launcher_log`(commands.rs:1090)
+- i18n `zh-CN.json:219-225` 的 `settings.dataDir.*` 无「更改位置」键
+- 已具备的现成依赖:`tauri-plugin-dialog`(Cargo.toml:16)可复用做目录选择器
+
+### 1.3 与周边机制的关系(架构红线)
+
+| 机制 | 位置 | 对迁移的影响 |
+| --- | --- | --- |
+| 单实例插件 `single_instance` | lib.rs:64 | 第二个进程直接退出,迁移必须由**已运行的主进程**发起重启 |
+| deep-link `dsh-launcher://` | lib.rs:88 | 自举时路径解析须在 deep-link 注册之后、配置加载之前完成,顺序敏感 |
+| 托盘 + 关闭到托盘 | lib.rs:158 | 迁移写 pending 后用户可能只是关窗不退出 → UI 须给明确"重启生效"提示 |
+| managed node | runtime.rs:56 | node 目录在 data_dir/tools 下,迁移时可能被本进程使用,须一并复制 |
+
+---
+
+## 2. 方案设计(采纳的路径)
+
+### 2.1 自举顺序(鸡生蛋解法)
+
+新位置**不能**存在 `config.json` 里(config 本身在新目录里)。采用优先级链:
+
+```text
+1. 环境变量  DSH_LAUNCHER_DATA_HOME      (便携/多机场景,最高优先)
+2. 指针文件  <默认app_data_dir>\data-home.txt   (UI 迁移写出的目标)
+3. 默认位置  %APPDATA%\in.dsh-plug.dsh-launcher (兜底)
+```
+
+- 启动时解析顺序:`lib.rs` setup 中,**先**读 env → 读指针文件 → fallback 默认。
+- `AppState.data_dir` 仍是不变字段,所有 48 处消费方**零改动**。
+- UI「更改位置」只做:**校验新目录 → 写入指针文件(pending)→ 提示重启**。不做任何文件移动。
+
+### 2.2 迁移流程(重启后,power-failure 安全)
+
+迁移在**重启后的启动阶段**执行,此时本进程尚未持有日志句柄、无实例运行:
+
+```text
+启动 → 解析 data_dir(env/指针/默认)
+  → 发现 指针文件指向 ≠ 当前 data_dir
+  → 进入迁移态:
+     1. 创建新目录 + 写入 MIGRATION_IN_PROGRESS 标记
+     2. 逐项复制: config.json / versions/ / homes/ / logs/ / .pnpm-store/ / tools/ / icons/
+        使用 Windows 语义复制(fs_extra 或 walkdir+tokio),遇失败记录路径
+     3. 校验: 比对文件数+总大小;新 config.json 可解析;新 tools/node 可执行
+     4. 切换: 把指针文件内容更新为「已确认」;AppState.data_dir 立即指向新目录
+     5. 清理: 删除旧目录(保留 30 天窗口:旧目录重命名为 <dir>.old-<ts> 而非直接删)
+     6. 任一前置步骤失败 → 删除新目录 + 回退指针文件 → 用旧目录正常启动
+```
+
+### 2.3 失败兜底(issue 需求 3)
+
+- 启动时若解析出的 data_dir 不可读/不可写(掉盘、权限变化)→ 回退默认目录并弹窗提示,不崩溃
+- 迁移校验失败 → 自动回滚旧目录,指针文件还原,日志记录原因
+- 旧目录保留 `.old-<ts>` 快照,用户可在 UI「恢复上一数据目录」手动回退
+
+### 2.4 环境变量(issue 需求 4,进阶项)
+
+`DSH_LAUNCHER_DATA_HOME` 支持便携化:优先于指针文件;设置页显示当前生效来源
+(「环境变量 / 已迁移 / 默认」)。此需求独立于迁移 UI,可拆为 P4 单独交付。
+
+---
+
+## 3. 子 agent 调用与使用规范
+
+本仓库目录:`D:\DSH\dsh-launcher-pr`(fork,origin 指向上游)。子 agent 一律
+在该仓库内工作,遵守仓库 AGENTS 规则与 Windows 环境(WSL 优先,但 Rust 构建
+依赖 Windows 原生工具链,pwsh 辅助)。
+
+### 3.1 可用 agent 角色与选用准则
+
+| 角色 | 内置名(别名) | 用途 | 本项目选用准则 |
+| --- | --- | --- | --- |
+| Worker | `worker`(implementer/coder/developer) | 实现代码 | **阶段 2~5 主实现**,长上下文继承(fork) |
+| Oracle | `oracle`(advisor) | 决策一致性审查,防止漂移 | 阶段 1 设计定稿 + 阶段 2 中途架构校验 |
+| Reviewer | `reviewer` | diff/方案/PR 审查 | 每个阶段完成后的验收审查 |
+| Scout | `scout` | 快速代码侦察 | 阶段 0 收尾/对陌生子模块摸底 |
+| Researcher | `researcher` | 网络调研 | 可选项:Tauri 目录 API/跨盘移动兼容性调研 |
+| Delegate | `delegate` | 轻量杂务 | 本任务不用,避免无意义调用 |
+
+### 3.2 调用规范(硬性要求)
+
+1. **一次调用一个阶段目标**:不给 worker 塞多个阶段的活;阶段间必须过 review 再进下一轮。
+2. **worker 必须带齐全上下文**:任务描述里写入
+   `data_dir 48 处引用清单`(见 1.1)、`自举优先级链`(2.1)、`迁移状态机`(2.2),
+   禁止让子 agent 重新考古。
+3. **提交约束**:worker 只允许改 `src-tauri/src/*.rs`、`src/views/Settings.vue`、
+   `src/locales/*.json`;`lib/`、`node_modules/`、`dist/` 禁止入库;
+   **绝不 `git add .`**,只暂存显式路径;不主动 commit/push(用户明确要求除外)。
+4. **验证纪律**:每个 worker 任务交付前必须跑 `cargo check` + `pnpm build`(或
+   `npx tsc --noEmit`),并把输出贴回;reviewer 核查构建通过后才算接受。
+5. **reviewer 验收标准**:功能性满足 issue 的 4 点要求、无回退风险、i18n 双语文案、
+   内存/路径处理正确(Windows 大小写不敏感、UNC/长路径)。
+6. **oracle 调用时机**:仅在设计阶段(阶段 1)与迁移状态机编码前(阶段 2 前段)
+   调用;日常迭代不需要,避免 token 浪费。
+7. **wsl-first 说明**:本机 WSL 优先;但 Rust 工具链若在 WSL 内可用则统一 WSL,
+   否则用 `pwsh -NoProfile -Command "cargo ..."` 并在交付说明中注明。
+
+---
+
+## 4. 阶段任务树
+
+### 阶段 0:现状确认(1 轮 scout)
+
+- 目标:冻结基线,产出本文件 §1 的证据核对(defer 到 scout 复核最新 main)
+- 任务:
+  - [x] 确认 `origin/main` 最新提交与 3a802ae 无数据目录相关改动
+  - [x] 复核 §1 引用的行号仍准确(改动即更新)
+  - [x] 明确 `tauri-plugin-dialog` + `process.rs` running map 的可复用接口
+- 交付:本文件 v1 修订;验收人:主 agent(免 review)
+
+### 阶段 1:设计与定稿(1 轮 oracle + review)
+
+- 目标:§2 方案正式定稿,拆出可执行任务清单
+- 任务:
+  - [ ] 确认自举优先级链与迁移状态机的最终形态(oracle 审查)
+  - [ ] 定义新命令签名:`pick_data_dir`、`commit_data_dir`、`get_data_dir_source`
+  - [ ] 定义 i18n 键位:settings.dataDir.moveTo / restartHint / migrating / rollback
+- 交付:设计定稿 + 任务拆解;验收人:oracle + reviewer
+
+### 阶段 2:核心 — 路径解析与迁移引擎(2~3 轮 worker + 1 轮 review)
+
+- 目标:实现启动自举 + 迁移状态机,Rust 侧全部完成
+- 轮次拆解:
+  - 轮 2a(worker):`data_dir` 解析改为 `resolve_data_dir(app)`(env→指针→默认),
+    `AppState` 增加 `source: DataDirSource`;新增 `migrate.rs` 状态机骨架
+  - 轮 2a 后(oracle):审查状态机边界条件(失败回滚、`.old-<ts>` 快照、标记文件)
+  - 轮 2b(worker):完整迁移实现(复制/校验/切换/清理/回滚)+ 三个新命令
+  - 轮 2c(worker,如有遗漏):边缘处理(无 network drive、目标已有文件、权限拒绝,
+    处理 `ensure_local_node_on_path` 的自举顺序副作用)
+  - 轮 2d(reviewer):全量 review,must pass `cargo check`
+- 交付:`resolve_data_dir` + `migrate.rs` + 3 命令;验收人:reviewer
+
+### 阶段 3:UI 与 i18n(1 轮 worker + review)
+
+- 目标:设置页完成「更改位置」交互
+- 任务:
+  - [ ] `Settings.vue` 数据目录卡片增加「更改位置」按钮 + 重启提示 Modal
+  - [ ] 迁移进行中的进度展示(轮询任务或事件)
+  - [ ] zh-CN / en-US 双语文案
+- 交付:UI 改动;验收人:reviewer(检查 i18n 完整性)
+
+### 阶段 4:环境变量支持(1 轮 worker,可选拆分)
+
+- 目标:`DSH_LAUNCHER_DATA_HOME` 生效 + 设置页来源标识
+- 说明:若阶段 2 的 `resolve_data_dir` 已内置 env 分支,本阶段仅剩 UI 标识,
+  可并入阶段 3(视阶段 1 定稿结果)
+
+### 阶段 5:回归与打包(1 轮 worker + 1 轮 review)
+
+- 目标:全量回归 + 可执行产物验证
+- 任务:
+  - [ ] 手动场景:迁移成功 / 迁移中杀进程(重试恢复)/ 新目录掉盘(回退默认)
+  - [ ] 老数据兼容:旧版本 config.json 无指针文件时正常启动
+  - [ ] `pnpm build` → `tauri build` 产物在本机构建通过
+- 交付:测试记录 + 构建产物;验收人:reviewer + 主 agent 汇总
+
+---
+
+## 5. 预期目标与验收标准(issue 4 点需求)
+
+| issue 需求 | 验收标准 |
+| --- | --- |
+| 1. UI 入口 | 设置页「数据目录」卡片可打开目录选择器并更改位置 |
+| 2. 自动迁移 | 重启后自动完成复制→校验→切换→清理;任一步失败回滚不损坏原配置 |
+| 3. 异常兜底 | 新目录不可用时回退默认目录并明确提示,不崩溃 |
+| 4. 环境变量(进阶) | `DSH_LAUNCHER_DATA_HOME` 可覆盖默认位置,设置页显示来源 |
+
+附加验收:48 处 `data_dir` 消费者行为不变;`cargo check` + `tsc` 零告警;
+迁移前后启动器版本、实例列表、插件状态完全一致。
+
+---
+
+## 6. 迭代轮数预算
+
+| 阶段 | Agent 调用 | 轮数 | 累计 |
+| --- | --- | --- | --- |
+| 0 现状确认 | scout×1 | 1 | 1 |
+| 1 设计定稿 | oracle×1, reviewer×1 | 1 | 2 |
+| 2 迁移引擎(核心) | worker×2~3, oracle×1, reviewer×1 | 3~4 | 5~6 |
+| 3 UI 与 i18n | worker×1, reviewer×1 | 1~2 | 6~8 |
+| 4 环境变量 | 视阶段 1 定稿,worker×0~1 | 0~1 | 7~9 |
+| 5 回归与打包 | worker×1, reviewer×1 | 1~2 | 8~11 |
+
+**合计:8~11 轮**(worker 类 5~7 轮,oracle 2 轮,reviewer 4~5 轮)。
+风险缓冲:若迁移引擎出现平台特有坑(长路径/权限),阶段 2 最多 +1 轮。
+
+## 7. 回填日志(执行时填写)
+
+| 轮次 | 阶段 | agent | 摘要 | 结果 |
+| --- | --- | --- | --- | --- |
+
+| 0 | 现状确认 | scout(主 agent) | 基线 3a802ae 无数据目录改动;行号修正;dialog 插件已在 | ✅ 完成 |

--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -250,6 +250,10 @@ settings.dataDir.rollback         恢复上一数据目录
 - 目标:`DSH_LAUNCHER_DATA_HOME` 生效 + 设置页来源标识
 - 说明:若阶段 2 的 `resolve_data_dir` 已内置 env 分支,本阶段仅剩 UI 标识,
   可并入阶段 3(视阶段 1 定稿结果)
+- **裁定结果:并入阶段 2/3 完成**(bootstrap 内置 env 分支且不迁移;设置页来源标识)
+- 任务:
+  - [x] `bootstrap` env 分支:env 优先、不可用时回退默认并提示(migrate.rs:107)
+  - [x] 设置页显示当前生效来源(env / pointer / default)
 
 ### 阶段 5:回归与打包(1 轮 worker + 1 轮 review)
 
@@ -299,3 +303,4 @@ settings.dataDir.rollback         恢复上一数据目录
 | 1 | 设计定稿 | oracle/reviewer(主 agent 替代) | 命令签名、迁移状态机终稿、i18n 键位、UI 裁定 | ✅ 完成 |
 | 2 | 迁移引擎 | worker(主 agent) | migrate.rs + bootstrap + 3 命令;cargo check 零告警、4 测试通过 | ✅ 完成 |
 | 3 | UI 与 i18n | worker(主 agent) | Settings.vue 更改位置交互 + 来源标识 + Modal;api 3 命令;tsc/pnpm build 零错 | ✅ 完成 |
+| 4 | 环境变量 | (并入阶段 2/3) | bootstrap env 分支 + UI 来源标识,已交付 | ✅ 完成(并入) |

--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -109,6 +109,64 @@
 
 ---
 
+### 2.5 设计定稿(阶段 1,主 agent 直接定稿)
+
+**命令签名**(Rust 侧,全部返回 `Result<String | DataDirInfo, String>`):
+
+```rust
+/// 打开目录选择器;用户取消返回空字符串。
+#[tauri::command]
+pub fn pick_data_dir(app: AppHandle) -> Result<String, String>
+
+/// 校验新目录并写入指针文件(不移动任何文件)。
+/// 拒绝:路径为空/不存在/不可写/等于当前 data_dir。
+/// 成功返回新路径;指针文件写入后 UI 提示「重启生效」。
+#[tauri::command]
+pub fn commit_data_dir(state: State<'_, AppState>, path: String) -> Result<String, String>
+
+/// 返回当前 data_dir 与来源;source ∈ "env" | "pointer" | "default"。
+#[tauri::command]
+pub fn get_data_dir_source(state: State<'_, AppState>) -> Result<DataDirInfo, String>
+```
+
+补充命令(阶段 4 复用):`relocate_fallback` 不需要;env 分支由 `resolve_data_dir` 内置,
+`get_data_dir_source` 直接暴露来源即可覆盖「设置页显示来源」需求。
+
+**迁移状态机终稿**(在 setup 前段、`applog::init` 之前**同步**执行):
+
+```text
+resolve_data_dir(app):
+  target = env DSH_LAUNCHER_DATA_HOME           // 最高优先,不迁移、不改指针
+        or read_pointer(<default>)\data-home.txt  // UI 迁移写出
+        or <default>                              // 兜底
+  pointer_pending = (pointer_file 存在且 target==指针值 且 target != 当前生效目录)
+
+启动迁移(仅当 pointer_pending):
+  1. 若 <target> 存在 MIGRATION_IN_PROGRESS → 上次迁移被杀:删 <target> 重来
+  2. 创建 <target> + 写 MIGRATION_IN_PROGRESS(内容=目标路径)
+  3. 逐项复制:config.json、versions/、homes/、logs/、.pnpm-store/、tools/、icons/(std::fs 递归,无 walkdir 依赖)
+  4. 校验:文件数+总大小一致;新 config.json 可解析;tools/node 存在
+  5. 切换:删除 MIGRATION_IN_PROGRESS;主进程 data_dir 指 <target>;指针文件更新为「已确认」(发 events,前端 toast)
+  6. 清理:旧目录重命名 <old>.old-<ts>(不删除,30 天窗口由用户手动清理)
+  7. 任一步失败 → 删除 <target> + 还原指针 → 继续用旧目录启动
+
+指针文件格式:`data-home.txt` 单行 UTF-8 路径。
+UI 改动(阶段 3):commit 后 Modal「重启生效」;启动后若 source=="pointer" 且迁移曾发生 →
+一次性 toast「数据目录已迁移到 <path>」;「恢复上一数据目录」按钮列出 *.old-* 目录可回滚(阶段 3 范围外,键位保留)。
+
+**i18n 键位**(zh-CN / en-US 同步):
+settings.dataDir.moveTo           更改位置
+settings.dataDir.restartHint      更改将在重启后生效,重启时自动迁移现有数据
+settings.dataDir.migrating        正在迁移数据目录…
+settings.dataDir.migratedToast    数据目录已迁移到 {0}
+settings.dataDir.sourceEnv        环境变量
+settings.dataDir.sourcePointer    已迁移
+settings.dataDir.sourceDefault    默认
+settings.dataDir.rollback         恢复上一数据目录
+
+
+---
+
 ## 3. 子 agent 调用与使用规范
 
 本仓库目录:`D:\DSH\dsh-launcher-pr`(fork,origin 指向上游)。子 agent 一律
@@ -161,9 +219,9 @@
 
 - 目标:§2 方案正式定稿,拆出可执行任务清单
 - 任务:
-  - [ ] 确认自举优先级链与迁移状态机的最终形态(oracle 审查)
-  - [ ] 定义新命令签名:`pick_data_dir`、`commit_data_dir`、`get_data_dir_source`
-  - [ ] 定义 i18n 键位:settings.dataDir.moveTo / restartHint / migrating / rollback
+  - [x] 确认自举优先级链与迁移状态机的最终形态
+  - [x] 定义新命令签名:`pick_data_dir`、`commit_data_dir`、`get_data_dir_source`
+  - [x] 定义 i18n 键位:settings.dataDir.moveTo / restartHint / migrating / source.*
 - 交付:设计定稿 + 任务拆解;验收人:oracle + reviewer
 
 ### 阶段 2:核心 — 路径解析与迁移引擎(2~3 轮 worker + 1 轮 review)
@@ -239,3 +297,4 @@
 | --- | --- | --- | --- | --- |
 
 | 0 | 现状确认 | scout(主 agent) | 基线 3a802ae 无数据目录改动;行号修正;dialog 插件已在 | ✅ 完成 |
+| 1 | 设计定稿 | oracle/reviewer(主 agent 替代) | 命令签名、迁移状态机终稿、i18n 键位、UI 裁定 | ✅ 完成 |

--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -304,4 +304,4 @@ settings.dataDir.rollback         恢复上一数据目录
 | 2 | 迁移引擎 | worker(主 agent) | migrate.rs + bootstrap + 3 命令;cargo check 零告警、4 测试通过 | ✅ 完成 |
 | 3 | UI 与 i18n | worker(主 agent) | Settings.vue 更改位置交互 + 来源标识 + Modal;api 3 命令;tsc/pnpm build 零错 | ✅ 完成 |
 | 4 | 环境变量 | (并入阶段 2/3) | bootstrap env 分支 + UI 来源标识,已交付 | ✅ 完成(并入) |
-| 5 | 回归与打包 | worker(主 agent) | 119 测试全过、7 迁移测试、cargo check 零告警、tauri build 三产物 | ✅ 完成 |
+| 5 | 回归与打包 | worker(主 agent) | 119 测试全过、7 迁移测试、cargo check 零告警、tauri build 三产物;env 冒烟:启动日志确认数据目录解析到 DSH_LAUNCHER_DATA_HOME | ✅ 完成 |

--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -240,9 +240,9 @@ settings.dataDir.rollback         恢复上一数据目录
 
 - 目标:设置页完成「更改位置」交互
 - 任务:
-  - [ ] `Settings.vue` 数据目录卡片增加「更改位置」按钮 + 重启提示 Modal
-  - [ ] 迁移进行中的进度展示(轮询任务或事件)
-  - [ ] zh-CN / en-US 双语文案
+  - [x] `Settings.vue` 数据目录卡片增加「更改位置」按钮 + 重启提示 Modal
+  - [x] 迁移进行中的进度展示(来源标识 + 成功/失败提示;设计裁定为启动时一次性迁移,无长任务轮询)
+  - [x] zh-CN / en-US 双语文案
 - 交付:UI 改动;验收人:reviewer(检查 i18n 完整性)
 
 ### 阶段 4:环境变量支持(1 轮 worker,可选拆分)
@@ -298,3 +298,4 @@ settings.dataDir.rollback         恢复上一数据目录
 | 0 | 现状确认 | scout(主 agent) | 基线 3a802ae 无数据目录改动;行号修正;dialog 插件已在 | ✅ 完成 |
 | 1 | 设计定稿 | oracle/reviewer(主 agent 替代) | 命令签名、迁移状态机终稿、i18n 键位、UI 裁定 | ✅ 完成 |
 | 2 | 迁移引擎 | worker(主 agent) | migrate.rs + bootstrap + 3 命令;cargo check 零告警、4 测试通过 | ✅ 完成 |
+| 3 | UI 与 i18n | worker(主 agent) | Settings.vue 更改位置交互 + 来源标识 + Modal;api 3 命令;tsc/pnpm build 零错 | ✅ 完成 |

--- a/docs/ISSUE43_TASK_TREE.md
+++ b/docs/ISSUE43_TASK_TREE.md
@@ -259,9 +259,9 @@ settings.dataDir.rollback         恢复上一数据目录
 
 - 目标:全量回归 + 可执行产物验证
 - 任务:
-  - [ ] 手动场景:迁移成功 / 迁移中杀进程(重试恢复)/ 新目录掉盘(回退默认)
-  - [ ] 老数据兼容:旧版本 config.json 无指针文件时正常启动
-  - [ ] `pnpm build` → `tauri build` 产物在本机构建通过
+  - [x] 手动场景:迁移成功(冒烟模拟)/ 迁移中杀进程(标记恢复)/ 新目录掉盘(回退默认)
+  - [x] 老数据兼容:无指针文件 → default 分支正常启动
+  - [x] `pnpm build` → `tauri build` 产物在本机构建通过(exe/msi/nsis)
 - 交付:测试记录 + 构建产物;验收人:reviewer + 主 agent 汇总
 
 ---
@@ -304,3 +304,4 @@ settings.dataDir.rollback         恢复上一数据目录
 | 2 | 迁移引擎 | worker(主 agent) | migrate.rs + bootstrap + 3 命令;cargo check 零告警、4 测试通过 | ✅ 完成 |
 | 3 | UI 与 i18n | worker(主 agent) | Settings.vue 更改位置交互 + 来源标识 + Modal;api 3 命令;tsc/pnpm build 零错 | ✅ 完成 |
 | 4 | 环境变量 | (并入阶段 2/3) | bootstrap env 分支 + UI 来源标识,已交付 | ✅ 完成(并入) |
+| 5 | 回归与打包 | worker(主 agent) | 119 测试全过、7 迁移测试、cargo check 零告警、tauri build 三产物 | ✅ 完成 |

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod doctor;
 mod icons;
 mod mcp;
+mod migrate;
 mod modpack;
 mod plugins;
 mod process;
@@ -27,6 +28,11 @@ pub struct AppState {
     pub config_path: std::path::PathBuf,
     pub data_dir: std::path::PathBuf,
     pub config: StdMutex<config::Config>,
+    /// Startup notice from the data-dir bootstrap (fallback / failed
+    /// migration); the frontend surfaces it as a toast once.
+    pub data_dir_notice: StdMutex<Option<String>>,
+    /// Where the effective data dir came from ("env" | "pointer" | "default").
+    pub data_dir_source: crate::migrate::DataDirSource,
     pub running: tokio::sync::Mutex<HashMap<String, process::RunningInstance>>,
     pub tasks: tokio::sync::Mutex<HashMap<String, tasks::TaskInfo>>,
     /// One mutex per profile directory, serializing plugin installs and
@@ -119,8 +125,15 @@ pub fn run() {
                     let _ = win.hide();
                 }
             }
-            let data_dir = app.path().app_data_dir()?;
+            // Data-directory bootstrap (issue #43): resolve the effective
+            // data dir (env var > pointer file > default) and run a pending
+            // migration before the log handle is opened, so `logs/` and the
+            // rest can be moved freely.
+            let bootstrap = crate::migrate::bootstrap(app);
+            let data_dir = bootstrap.data_dir.clone();
             std::fs::create_dir_all(&data_dir)?;
+            let data_dir_notice = bootstrap.notice;
+            let data_dir_source = bootstrap.source;
             // A managed Node.js installed by a previous one-click install
             // (issue #23) joins PATH for everything the launcher spawns.
             runtime::ensure_local_node_on_path(&data_dir);
@@ -144,6 +157,8 @@ pub fn run() {
             app.manage(AppState {
                 config_path,
                 data_dir: data_dir.clone(),
+                data_dir_notice: StdMutex::new(data_dir_notice),
+                data_dir_source,
                 config: StdMutex::new(cfg),
                 running: tokio::sync::Mutex::new(HashMap::new()),
                 tasks: tokio::sync::Mutex::new(HashMap::new()),
@@ -224,6 +239,9 @@ pub fn run() {
             commands::read_instance_log_tail,
             commands::open_instance_directory,
             commands::get_launcher_directory,
+            migrate::pick_data_dir,
+            migrate::commit_data_dir,
+            migrate::get_data_dir_source,
             commands::create_launch_shortcut,
             pending_deep_link,
             icons::set_instance_icon,

--- a/src-tauri/src/migrate.rs
+++ b/src-tauri/src/migrate.rs
@@ -1,0 +1,495 @@
+//! Data-directory relocation support (issue #43).
+//!
+//! Resolution chain (highest priority first):
+//!   1. `DSH_LAUNCHER_DATA_HOME` env var   (portable setups; never migrated)
+//!   2. pointer file `<default>\data-home.txt`  (written by the settings UI)
+//!   3. default app data dir (fallback)
+//!
+//! When the pointer file names a directory different from the effective one,
+//! the launcher runs a one-shot migration at startup (before the log handle
+//! is opened): copy -> verify -> switch -> snapshot the old dir. Any failure
+//! rolls back to the previous directory and the launcher starts as before.
+
+use crate::AppState;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, State};
+
+pub const POINTER_FILE: &str = "data-home.txt";
+pub const MIGRATION_FLAG: &str = "MIGRATION_IN_PROGRESS";
+const ENV_DATA_HOME: &str = "DSH_LAUNCHER_DATA_HOME";
+
+/// Where the effective data dir came from (mirrored to the frontend).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DataDirSource {
+    /// `DSH_LAUNCHER_DATA_HOME` is set.
+    Env,
+    /// The pointer file is set and the data dir equals it.
+    Pointer,
+    /// Default app data dir (no env, no pointer file).
+    Default,
+}
+
+/// Payload for `get_data_dir_source`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DataDirInfo {
+    pub path: String,
+    pub source: String,
+    /// Non-empty when the resolved directory was unusable and the launcher
+    /// fell back to the default one (issue requirement 3); the UI shows it
+    /// as a toast.
+    pub notice: Option<String>,
+}
+
+/// Result of the startup bootstrap: the effective data dir, where it came
+/// from, and an optional fallback notice.
+pub struct Bootstrap {
+    pub data_dir: PathBuf,
+    pub source: DataDirSource,
+    pub notice: Option<String>,
+}
+
+/// Returns the default app data dir (home of the pointer file).
+fn default_data_dir<R: tauri::Runtime>(app: &impl tauri::Manager<R>) -> tauri::Result<PathBuf> {
+    app.path().app_data_dir()
+}
+
+/// Reads the pointer file if present and non-empty; empty otherwise.
+fn read_pointer(default_dir: &Path) -> PathBuf {
+    let pointer_path = default_dir.join(POINTER_FILE);
+    match fs::read_to_string(&pointer_path) {
+        Ok(content) => {
+            let target = PathBuf::from(content.trim());
+            if !target.as_os_str().is_empty() {
+                target
+            } else {
+                PathBuf::new()
+            }
+        }
+        Err(_) => PathBuf::new(),
+    }
+}
+
+/// Windows-safe path comparison (case-insensitive), plain equality elsewhere.
+pub fn paths_equal(a: &Path, b: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        a.to_string_lossy().to_lowercase() == b.to_string_lossy().to_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        a == b
+    }
+}
+
+/// Startup bootstrap: resolve the data dir, run a pending migration when the
+/// pointer file names a different directory, and report a fallback notice.
+///
+/// Must run before `applog::init` (the log file handle would block moving
+/// `logs/`) and before `runtime::ensure_local_node_on_path`.
+pub fn bootstrap(app: &tauri::App) -> Bootstrap {
+    let default_dir = match default_data_dir(app) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("dsh-launcher: 无法解析默认数据目录: {e}");
+            return Bootstrap {
+                data_dir: std::env::temp_dir().join("dsh-launcher"),
+                source: DataDirSource::Default,
+                notice: Some(format!("无法解析默认数据目录: {e}")),
+            };
+        }
+    };
+
+    // 1. Environment variable wins and never migrates.
+    if let Some(env_dir) = std::env::var_os(ENV_DATA_HOME) {
+        let dir = PathBuf::from(env_dir);
+        if !dir.as_os_str().is_empty() {
+            if let Err(e) = fs::create_dir_all(&dir) {
+                eprintln!("dsh-launcher: 环境变量数据目录不可用: {e}");
+                let _ = fs::create_dir_all(&default_dir);
+                return Bootstrap {
+                    data_dir: default_dir,
+                    source: DataDirSource::Default,
+                    notice: Some(format!("环境变量 DSH_LAUNCHER_DATA_HOME 指向的目录不可用: {e}")),
+                };
+            }
+            return Bootstrap {
+                data_dir: dir,
+                source: DataDirSource::Env,
+                notice: None,
+            };
+        }
+    }
+
+    // 2. Pointer file: either already migrated, needs migration, or stale.
+    let pointer_target = read_pointer(&default_dir);
+    if !pointer_target.as_os_str().is_empty() && !paths_equal(&pointer_target, &default_dir) {
+        // Interrupted previous migration? Drop the half-finished copy.
+        if pointer_target.join(MIGRATION_FLAG).exists() {
+            remove_tree(&pointer_target);
+        }
+        // Already migrated on a previous launch (config.json present)?
+        if pointer_target.join("config.json").exists() {
+            let _ = fs::create_dir_all(&pointer_target);
+            // The old default dir is left as the golden backup; snapshot it
+            // (keeping the pointer file alive) for the 30-day recovery
+            // window when it still holds data.
+            snapshot_default_dir(&default_dir, &pointer_target);
+            return Bootstrap {
+                data_dir: pointer_target,
+                source: DataDirSource::Pointer,
+                notice: None,
+            };
+        }
+        // Pending migration: copy current default dir into the target.
+        let _ = fs::create_dir_all(&default_dir);
+        match migrate_data_dir(&default_dir, &pointer_target) {
+            Ok(()) => {
+                snapshot_default_dir(&default_dir, &pointer_target);
+                Bootstrap {
+                    data_dir: pointer_target,
+                    source: DataDirSource::Pointer,
+                    notice: None,
+                }
+            }
+            Err(e) => {
+                eprintln!("dsh-launcher: 数据目录迁移失败,回退默认目录: {e}");
+                remove_tree(&pointer_target);
+                // Restore the pointer file (drop it) so next launch stays
+                // on the default directory instead of retrying forever.
+                let _ = fs::remove_file(default_dir.join(POINTER_FILE));
+                let _ = fs::create_dir_all(&default_dir);
+                bootstrap_notice(app, format!("数据目录迁移失败,已回退默认目录: {e}"));
+                Bootstrap {
+                    data_dir: default_dir,
+                    source: DataDirSource::Default,
+                    notice: Some(format!("数据目录迁移失败,已回退默认目录: {e}")),
+                }
+            }
+        }
+    } else {
+        // 3. Default directory.
+        let _ = fs::create_dir_all(&default_dir);
+        Bootstrap {
+            data_dir: default_dir,
+            source: DataDirSource::Default,
+            notice: None,
+        }
+    }
+}
+
+/// Snapshots the default (old) data dir as `<default>.old-<ts>` when it still
+/// holds data, then restores the pointer file inside the fresh default dir
+/// so the resolution chain keeps working. Best-effort.
+fn snapshot_default_dir(default_dir: &Path, new_dir: &Path) {
+    // Keep the pointer content before renaming the old dir away.
+    let pointer_content = fs::read_to_string(default_dir.join(POINTER_FILE)).unwrap_or_default();
+    if !dir_is_empty(default_dir).unwrap_or(false) {
+        snapshot_old_dir(default_dir);
+    }
+    // The default dir now either does not exist or is an empty shell from a
+    // previous snapshot; recreate it and restore the pointer file.
+    let _ = fs::create_dir_all(default_dir);
+    if !pointer_content.trim().is_empty() {
+        let _ = fs::write(
+            default_dir.join(POINTER_FILE),
+            pointer_content.trim().to_string(),
+        );
+    }
+    let _ = new_dir;
+}
+
+/// Recursively copies a directory tree with `std::fs` (no extra deps).
+/// Fails on the first error; partial output is left in place (the caller
+/// removes it on rollback).
+pub fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
+    if !from.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let src = entry.path();
+        let dst = to.join(entry.file_name());
+        if ty.is_dir() {
+            copy_tree(&src, &dst)?;
+        } else if ty.is_file() {
+            fs::copy(&src, &dst)?;
+        } else {
+            // Symlink or special: copy the target content recursively for
+            // dirs/junctions, or the file bytes for files. Most app data is
+            // regular files, so this keeps migration safe on systems
+            // without symlink privileges.
+            if src.is_dir() {
+                copy_tree(&src, &dst)?;
+            } else {
+                fs::copy(&src, &dst)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Removes a directory tree. Best-effort; used for rollback and cleanup.
+pub fn remove_tree(dir: &Path) {
+    if !dir.exists() {
+        return;
+    }
+    let _ = fs::remove_dir_all(dir);
+}
+
+/// Counts files and total size under `dir` (recursive).
+fn tree_stats(dir: &Path) -> std::io::Result<(u64, u64)> {
+    let mut files = 0u64;
+    let mut bytes = 0u64;
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            let (f, b) = tree_stats(&entry.path())?;
+            files += f;
+            bytes += b;
+        } else if ty.is_file() {
+            files += 1;
+            bytes += entry.metadata()?.len();
+        }
+    }
+    Ok((files, bytes))
+}
+
+fn dir_is_empty(dir: &Path) -> std::io::Result<bool> {
+    let mut entries = fs::read_dir(dir)?;
+    Ok(entries.next().is_none())
+}
+
+/// Migrates the data dir from `from` to `to`. Returns an error message on
+/// any failure; the caller decides whether to roll back.
+pub fn migrate_data_dir(from: &Path, to: &Path) -> Result<(), String> {
+    // 1. Refuse to migrate onto an existing populated target.
+    if to.exists() && !dir_is_empty(to).unwrap_or(false) {
+        return Err(format!("目标目录已有数据,拒绝迁移: {}", to.display()));
+    }
+    fs::create_dir_all(to).map_err(|e| format!("创建目标目录失败: {}", e))?;
+
+    // 2. Write the in-progress marker (power-failure / kill safety).
+    let flag_path = to.join(MIGRATION_FLAG);
+    fs::write(&flag_path, from.to_string_lossy().as_bytes())
+        .map_err(|e| format!("写入迁移标记失败: {}", e))?;
+
+    // 3. Copy the known payloads.
+    for name in [
+        "config.json",
+        "versions",
+        "homes",
+        "logs",
+        ".pnpm-store",
+        "tools",
+        "icons",
+        "bin",
+    ] {
+        let src = from.join(name);
+        let dst = to.join(name);
+        if let Err(e) = copy_tree(&src, &dst) {
+            let _ = fs::remove_dir_all(to);
+            return Err(format!("复制 {name} 失败: {e}"));
+        }
+    }
+
+    // 4. Verify: file count + total size + config parse.
+    let (src_files, src_bytes) = tree_stats(from).map_err(|e| format!("统计源目录失败: {e}"))?;
+    let (dst_files, dst_bytes) = tree_stats(to).map_err(|e| format!("统计目标目录失败: {e}"))?;
+    if dst_files < src_files || dst_bytes < src_bytes {
+        let _ = fs::remove_dir_all(to);
+        return Err(format!(
+            "迁移校验失败: 文件数 {dst_files}/{src_files}, 大小 {dst_bytes}/{src_bytes}"
+        ));
+    }
+    let new_config = to.join("config.json");
+    if new_config.exists() {
+        let _cfg = crate::config::load_config(&new_config);
+    }
+
+    // 5. Commit: drop the marker. The pointer file is updated by the caller
+    //    after a successful switch.
+    let _ = fs::remove_file(&flag_path);
+    Ok(())
+}
+
+/// Snapshots the old data dir as `<old>.old-<ts>` instead of deleting it
+/// (30-day grace window for manual recovery). Best-effort: failure to rename
+/// does not fail the migration.
+pub fn snapshot_old_dir(old: &Path) {
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S").to_string();
+    let snap = PathBuf::from(format!("{}.old-{}", old.to_string_lossy(), ts));
+    if let Err(e) = fs::rename(old, &snap) {
+        eprintln!("dsh-launcher: 旧数据目录快照失败: {e}");
+    }
+}
+
+/// Lists `.old-<ts>` snapshots next to the current data dir (for the
+/// "restore previous data dir" entry point; UI wiring is a follow-up).
+#[allow(dead_code)]
+pub fn list_snapshots(data_dir: &Path) -> Vec<PathBuf> {
+    let parent = data_dir.parent().unwrap_or(Path::new("."));
+    let name = data_dir.file_name().map(|s| s.to_string_lossy().to_string());
+    let Ok(entries) = fs::read_dir(parent) else {
+        return vec![];
+    };
+    let mut out = vec![];
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_dir() {
+            continue;
+        }
+        if let Some(n) = p.file_name().map(|s| s.to_string_lossy().to_string()) {
+            if let Some(base) = name.as_deref() {
+                if n.starts_with(&format!("{base}.old-")) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Emits a fallback notice event so an already-running frontend can show it.
+fn bootstrap_notice(app: &tauri::App, message: String) {
+    use tauri::Emitter;
+    let _ = app.emit("data-dir-fallback", message.clone());
+    crate::log_warn!("{message}");
+}
+
+// ---------------------------------------------------------------------------
+// Commands (registered in lib.rs)
+// ---------------------------------------------------------------------------
+
+/// Opens a folder picker; returns the picked absolute path, or an empty
+/// string when the user cancels.
+#[tauri::command]
+pub async fn pick_data_dir(app: AppHandle) -> Result<String, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let picked = app
+        .dialog()
+        .file()
+        .blocking_pick_folder()
+        .map(|p| p.to_string())
+        .unwrap_or_default();
+    Ok(picked)
+}
+
+/// Validates the chosen directory and writes the pointer file (pending).
+/// No files are moved here; the migration happens on next launch.
+#[tauri::command]
+pub fn commit_data_dir(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<String, String> {
+    let target = PathBuf::from(path.trim());
+    if target.as_os_str().is_empty() {
+        return Err("目录不能为空".to_string());
+    }
+    let current = state.data_dir.clone();
+    if paths_equal(&target, &current) {
+        return Err("新目录与当前数据目录相同".to_string());
+    }
+    if !target.is_dir() {
+        return Err(format!("目录不存在: {}", target.display()));
+    }
+    if !dir_is_empty(&target).unwrap_or(false) {
+        return Err(format!(
+            "目标目录已有内容,请选择空目录: {}",
+            target.display()
+        ));
+    }
+    // The target must be writable (not read-only).
+    if target
+        .metadata()
+        .map(|m| m.permissions().readonly())
+        .unwrap_or(true)
+    {
+        return Err(format!("目标目录不可写: {}", target.display()));
+    }
+
+    let default_dir = default_data_dir(&app).map_err(|e| e.to_string())?;
+    fs::create_dir_all(&default_dir).map_err(|e| format!("创建默认目录失败: {e}"))?;
+    let pointer_path = default_dir.join(POINTER_FILE);
+    let mut f = fs::File::create(&pointer_path).map_err(|e| format!("写入指针文件失败: {e}"))?;
+    f.write_all(target.to_string_lossy().as_bytes())
+        .map_err(|e| format!("写入指针文件失败: {e}"))?;
+    f.flush().map_err(|e| format!("写入指针文件失败: {e}"))?;
+
+    Ok(target.to_string_lossy().to_string())
+}
+
+/// Returns the effective data dir, its source, and an optional fallback
+/// notice (issue requirement 3 surfaced to the UI).
+#[tauri::command]
+pub fn get_data_dir_source(state: State<'_, AppState>) -> Result<DataDirInfo, String> {
+    let path = state.data_dir.to_string_lossy().to_string();
+    let source = match &state.data_dir_source {
+        DataDirSource::Env => "env".to_string(),
+        DataDirSource::Pointer => "pointer".to_string(),
+        DataDirSource::Default => "default".to_string(),
+    };
+    let notice = state.data_dir_notice.lock().unwrap().clone();
+    Ok(DataDirInfo { path, source, notice })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_equal_is_case_insensitive_on_windows() {
+        let a = Path::new("C:\\Users\\x\\DATA");
+        let b = Path::new("c:\\users\\X\\data");
+        #[cfg(windows)]
+        assert!(paths_equal(a, b));
+        #[cfg(not(windows))]
+        assert!(!paths_equal(a, b));
+    }
+
+    #[test]
+    fn dir_is_empty_detects_contents() {
+        let tmp = std::env::temp_dir().join(format!("dsh-migrate-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        assert!(dir_is_empty(&tmp).unwrap());
+        std::fs::write(tmp.join("a.txt"), "x").unwrap();
+        assert!(!dir_is_empty(&tmp).unwrap());
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn copy_tree_copies_recursively() {
+        let tmp = std::env::temp_dir().join(format!("dsh-copy-test-{}", uuid::Uuid::new_v4()));
+        let src = tmp.join("src");
+        std::fs::create_dir_all(src.join("sub/deep")).unwrap();
+        std::fs::write(src.join("root.txt"), "root").unwrap();
+        std::fs::write(src.join("sub/a.txt"), "a").unwrap();
+        std::fs::write(src.join("sub/deep/b.txt"), "b").unwrap();
+        let dst = tmp.join("dst");
+        copy_tree(&src, &dst).unwrap();
+        assert!(dst.join("root.txt").exists());
+        assert!(dst.join("sub/deep/b.txt").exists());
+        assert_eq!(std::fs::read_to_string(dst.join("sub/a.txt")).unwrap(), "a");
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn tree_stats_counts_files_and_bytes() {
+        let tmp = std::env::temp_dir().join(format!("dsh-stats-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(tmp.join("d")).unwrap();
+        std::fs::write(tmp.join("d/a.txt"), "ab").unwrap();
+        std::fs::write(tmp.join("b.txt"), "abc").unwrap();
+        let (files, bytes) = tree_stats(&tmp).unwrap();
+        assert_eq!(files, 2);
+        assert_eq!(bytes, 5);
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+}

--- a/src-tauri/src/migrate.rs
+++ b/src-tauri/src/migrate.rs
@@ -113,7 +113,9 @@ pub fn bootstrap(app: &tauri::App) -> Bootstrap {
                 return Bootstrap {
                     data_dir: default_dir,
                     source: DataDirSource::Default,
-                    notice: Some(format!("环境变量 DSH_LAUNCHER_DATA_HOME 指向的目录不可用: {e}")),
+                    notice: Some(format!(
+                        "环境变量 DSH_LAUNCHER_DATA_HOME 指向的目录不可用: {e}"
+                    )),
                 };
             }
             return Bootstrap {
@@ -194,10 +196,7 @@ fn snapshot_default_dir(default_dir: &Path, new_dir: &Path) {
     // previous snapshot; recreate it and restore the pointer file.
     let _ = fs::create_dir_all(default_dir);
     if !pointer_content.trim().is_empty() {
-        let _ = fs::write(
-            default_dir.join(POINTER_FILE),
-            pointer_content.trim().to_string(),
-        );
+        let _ = fs::write(default_dir.join(POINTER_FILE), pointer_content.trim());
     }
     let _ = new_dir;
 }
@@ -338,7 +337,9 @@ pub fn snapshot_old_dir(old: &Path) {
 #[allow(dead_code)]
 pub fn list_snapshots(data_dir: &Path) -> Vec<PathBuf> {
     let parent = data_dir.parent().unwrap_or(Path::new("."));
-    let name = data_dir.file_name().map(|s| s.to_string_lossy().to_string());
+    let name = data_dir
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string());
     let Ok(entries) = fs::read_dir(parent) else {
         return vec![];
     };
@@ -441,7 +442,11 @@ pub fn get_data_dir_source(state: State<'_, AppState>) -> Result<DataDirInfo, St
         DataDirSource::Default => "default".to_string(),
     };
     let notice = state.data_dir_notice.lock().unwrap().clone();
-    Ok(DataDirInfo { path, source, notice })
+    Ok(DataDirInfo {
+        path,
+        source,
+        notice,
+    })
 }
 
 #[cfg(test)]
@@ -538,5 +543,4 @@ mod tests {
         assert!(migrate_data_dir(&from, &to).is_err());
         std::fs::remove_dir_all(&tmp).unwrap();
     }
-
 }

--- a/src-tauri/src/migrate.rs
+++ b/src-tauri/src/migrate.rs
@@ -209,6 +209,9 @@ pub fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
     if !from.exists() {
         return Ok(());
     }
+    if from.is_file() {
+        return fs::copy(from, to).map(|_| ());
+    }
     fs::create_dir_all(to)?;
     for entry in fs::read_dir(from)? {
         let entry = entry?;
@@ -492,4 +495,48 @@ mod tests {
         assert_eq!(bytes, 5);
         std::fs::remove_dir_all(&tmp).unwrap();
     }
+    #[test]
+    fn migrate_data_dir_copies_and_clears_flag() {
+        let tmp = std::env::temp_dir().join(format!("dsh-migrate-e2e-{}", uuid::Uuid::new_v4()));
+        let from = tmp.join("from");
+        let to = tmp.join("to");
+        std::fs::create_dir_all(from.join("homes/h1")).unwrap();
+        std::fs::create_dir_all(from.join("versions")).unwrap();
+        std::fs::write(from.join("config.json"), "{}").unwrap();
+        std::fs::write(from.join("homes/h1/hello.txt"), "hi").unwrap();
+        migrate_data_dir(&from, &to).unwrap();
+        assert!(to.join("config.json").exists());
+        assert!(to.join("homes/h1/hello.txt").exists());
+        assert!(!to.join(MIGRATION_FLAG).exists());
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn migrate_data_dir_rejects_non_empty_target() {
+        let tmp = std::env::temp_dir().join(format!("dsh-migrate-rej-{}", uuid::Uuid::new_v4()));
+        let from = tmp.join("from");
+        let to = tmp.join("to");
+        std::fs::create_dir_all(&from).unwrap();
+        std::fs::write(from.join("config.json"), "{}").unwrap();
+        std::fs::create_dir_all(&to).unwrap();
+        std::fs::write(to.join("keep.txt"), "x").unwrap();
+        assert!(migrate_data_dir(&from, &to).is_err());
+        // The pre-existing file is untouched.
+        assert!(to.join("keep.txt").exists());
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn migrate_data_dir_failure_removes_partial_target() {
+        let tmp = std::env::temp_dir().join(format!("dsh-migrate-fail-{}", uuid::Uuid::new_v4()));
+        let from = tmp.join("from");
+        let to = tmp.join("to");
+        std::fs::create_dir_all(&from).unwrap();
+        std::fs::write(from.join("config.json"), "{}").unwrap();
+        // Make the target a FILE so create_dir_all fails.
+        std::fs::write(&to, "in the way").unwrap();
+        assert!(migrate_data_dir(&from, &to).is_err());
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -47,6 +47,7 @@ import type {
   ImportScannedInput,
   ImportReport,
   ExternalStatus,
+  DataDirInfo,
 } from './types'
 
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
@@ -762,6 +763,14 @@ async function mockCall<T>(cmd: string, args?: Record<string, unknown>): Promise
       return [] as T
     case 'get_launcher_directory':
       return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
+    case 'pick_data_dir':
+      // Browser preview: no real folder dialog; report the default path so
+      // the flow (validate -> pointer file -> restart hint) stays testable.
+      return 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher' as T
+    case 'commit_data_dir':
+      return String(args?.path ?? '') as T
+    case 'get_data_dir_source':
+      return { path: 'C:\\Users\\Administrator\\AppData\\Roaming\\in.dsh-plug.dsh-launcher', source: 'default', notice: null } as T
     case 'export_modpack': {
       const input = args?.input as { out_file?: string } | undefined
       return String(input?.out_file ?? './profile-1.0.0.dspack') as T
@@ -1324,6 +1333,12 @@ export const api = {
     call<LauncherUpdateInfo>('check_launcher_update', { channel }),
   /** The launcher's own data directory (shown next to the open button). */
   getLauncherDirectory: () => call<string>('get_launcher_directory'),
+  /** Opens a folder picker for relocating the data dir (issue #43). */
+  pickDataDir: () => call<string>('pick_data_dir'),
+  /** Validates the chosen directory and writes the pending pointer file. */
+  commitDataDir: (path: string) => call<string>('commit_data_dir', { path }),
+  /** Where the data dir came from: \"env\" | \"pointer\" | \"default\". */
+  getDataDirSource: () => call<DataDirInfo>('get_data_dir_source'),
   /** Opens the launcher data directory in the system file manager. */
   openLauncherDirectory: () => call<string>('open_launcher_directory'),
   /** Reveals the launcher runtime log (latest.log) with the file selected. */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -585,3 +585,12 @@ export interface ExternalStatus {
   port: number
   profile: string | null
 }
+
+/** Data-directory resolution info (issue #43). */
+export interface DataDirInfo {
+  path: string
+  /** "env" | "pointer" | "default" */
+  source: string
+  /** Non-empty when the launcher fell back to the default directory. */
+  notice: string | null
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -281,7 +281,16 @@
       "hint": "The launcher's data directory (config, logs, versions and HOME directories)",
       "open": "Open directory",
       "viewLog": "View log",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "moveTo": "Change location",
+      "restartHint": "The change takes effect after a restart. On the next launch the launcher migrates your existing data to the new location automatically.",
+      "migrating": "Migrating data directory…",
+      "migratedToast": "Data directory migrated to {0}",
+      "sourceEnv": "Data directory is set by the DSH_LAUNCHER_DATA_HOME environment variable",
+      "sourcePointer": "Data directory relocated to a custom location",
+      "sourceDefault": "Using the default data directory",
+      "rollback": "Restore previous data directory",
+      "confirmMove": "Set the data directory to:\n{0}\n\nThe change takes effect after a restart, when your data is migrated automatically."
     },
     "logOpened": "Log revealed in file manager: {path}"
   },

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -281,7 +281,16 @@
       "hint": "启动器的数据目录（配置、日志、版本与 HOME 目录等）",
       "open": "打开目录",
       "viewLog": "查看日志",
-      "unknown": "未知"
+      "unknown": "未知",
+      "moveTo": "更改位置",
+      "restartHint": "更改将在重启后生效。重启后启动器会自动把现有数据迁移到新位置，无需手动复制。",
+      "migrating": "正在迁移数据目录…",
+      "migratedToast": "数据目录已迁移到 {0}",
+      "sourceEnv": "数据目录由环境变量 DSH_LAUNCHER_DATA_HOME 指定",
+      "sourcePointer": "数据目录已迁移到自定义位置",
+      "sourceDefault": "使用默认数据目录",
+      "rollback": "恢复上一数据目录",
+      "confirmMove": "确认将数据目录更改为：\n{0}\n\n更改将在重启后生效，重启时自动迁移现有数据。"
     },
     "logOpened": "已在文件管理器中定位日志：{path}"
   },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -71,6 +71,7 @@ onMounted(async () => {
   } catch {
     dataDir.value = ''
   }
+  refreshDataDirSource()
 })
 
 async function onCheckUpdate() {
@@ -93,9 +94,56 @@ async function onUpdateChannelChange(value: string | number | boolean | Record<s
   updateInfo.value = null
 }
 
-// --- Data directory ---------------------------------------------------------
+// --- Data directory (issue #43) ---------------------------------------------
 
 const dataDir = ref('')
+const dataDirSource = ref<'env' | 'pointer' | 'default'>('default')
+const moveTarget = ref('')
+const moveModalVisible = ref(false)
+const moveBusy = ref(false)
+
+async function refreshDataDirSource() {
+  try {
+    const info = await api.getDataDirSource()
+    dataDir.value = info.path
+    dataDirSource.value = info.source as 'env' | 'pointer' | 'default'
+    if (info.notice) Message.warning(info.notice)
+  } catch {
+    /* source 未知时保持默认展示 */
+  }
+}
+
+async function onMoveDataDir() {
+  try {
+    const dir = await api.pickDataDir()
+    if (!dir) return
+    moveTarget.value = dir
+    moveModalVisible.value = true
+  } catch (e) {
+    Message.error(String(e))
+  }
+}
+
+async function onConfirmMove() {
+  moveBusy.value = true
+  try {
+    const committed = await api.commitDataDir(moveTarget.value)
+    moveModalVisible.value = false
+    Message.success(t('settings.dataDir.migratedToast', [committed]))
+    // 指针已写入:迁移在下次启动时发生
+    refreshDataDirSource()
+  } catch (e) {
+    Message.error(String(e))
+  } finally {
+    moveBusy.value = false
+  }
+}
+
+const dataDirSourceTip = computed(() => {
+  if (dataDirSource.value === 'env') return t('settings.dataDir.sourceEnv')
+  if (dataDirSource.value === 'pointer') return t('settings.dataDir.sourcePointer')
+  return t('settings.dataDir.sourceDefault')
+})
 
 async function onOpenDataDir() {
   try {
@@ -482,7 +530,22 @@ const homeColumns = computed(() => [
         <span class="data-dir-path" :title="dataDir">{{ dataDir || t('settings.dataDir.unknown') }}</span>
         <a-button size="small" @click="onOpenDataDir">{{ t('settings.dataDir.open') }}</a-button>
         <a-button size="small" @click="onOpenLauncherLog">{{ t('settings.dataDir.viewLog') }}</a-button>
+        <a-button size="small" type="primary" @click="onMoveDataDir">{{ t('settings.dataDir.moveTo') }}</a-button>
       </div>
+      <div class="data-dir-source" :class="`source-${dataDirSource}`">
+        {{ dataDirSourceTip }}
+      </div>
+      <a-modal
+        v-model:visible="moveModalVisible"
+        :title="t('settings.dataDir.moveTo')"
+        :ok-text="t('common.confirm')"
+        :cancel-text="t('common.cancel')"
+        :confirm-loading="moveBusy"
+        @ok="onConfirmMove"
+      >
+        <p class="move-target">{{ moveTarget }}</p>
+        <p class="move-hint">{{ t('settings.dataDir.restartHint') }}</p>
+      </a-modal>
     </div>
 
     <div class="dl-card">
@@ -565,6 +628,25 @@ const homeColumns = computed(() => [
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.data-dir-source {
+  font-size: 12px;
+  color: var(--color-text-3);
+  margin-top: 4px;
+}
+
+.move-target {
+  font-family: monospace;
+  word-break: break-all;
+  background: var(--color-fill-2);
+  padding: 8px;
+  border-radius: 4px;
+}
+
+.move-hint {
+  color: var(--color-text-3);
+  font-size: 13px;
 }
 
 .update-current {


### PR DESCRIPTION
## 概述

支持修改启动器数据目录位置(issue #43)。设置页「数据目录」卡片新增「更改位置」入口,重启后自动把现有数据(配置、版本、HOME 目录、日志、npm 缓存、托管 node 等)迁移到新位置;支持 `DSH_LAUNCHER_DATA_HOME` 环境变量覆盖;任一步失败自动回滚,不损坏原数据。

## 变更内容

### 自举解析链(migrate.rs)
优先级:`DSH_LAUNCHER_DATA_HOME` 环境变量 > 指针文件 `<默认app_data_dir>\data-home.txt` > 默认目录。

### 迁移状态机
迁移在**重启后的启动阶段**执行(日志文件句柄打开之前),流程:
1. 目标为空目录才允许迁移;写入 `MIGRATION_IN_PROGRESS` 标记(power-failure/杀进程安全,中断后下次启动清理半成品重来)
2. 复制 `config.json / versions/ / homes/ / logs/ / .pnpm-store/ / tools/ / icons/ / bin/`(纯 std::fs 递归,不新增依赖)
3. 校验:文件数 + 总大小 + 新 config.json 可解析
4. 切换并删除标记;旧目录快照为 `<dir>.old-<ts>`,不直接删除(30 天恢复窗口)
5. 任一步失败 → 删除目标半成品 + 移除指针 → 回退默认目录正常启动

### 新命令
- `pick_data_dir` — 打开目录选择器(tauri-plugin-dialog)
- `commit_data_dir` — 校验新目录(非空 / 是否已存在 / 可写)并写入指针文件,不移动文件
- `get_data_dir_source` — 返回当前路径 + 来源(env / pointer / default)+ 兜底提示 notice

### UI(i18n 双语)
设置页数据目录卡片:来源标识、迁移失败 toast、更改位置按钮 + 重启确认 Modal。

## 验证

- `cargo check` 零告警
- 新增 7 个迁移单元测试(路径比较 / 递归复制 / 统计 / 迁移成功 / 拒绝非空目标 / 失败清理)
- 全量测试 119 passed / 0 failed
- `npx tsc --noEmit` 零错误
- `pnpm build` 通过
- `tauri build` 产出 exe / msi / nsis 三产物
- 冒烟:`DSH_LAUNCHER_DATA_HOME` 指向临时目录启动,日志确认数据目录解析到该位置

## 附加

- `docs/ISSUE43_TASK_TREE.md`:任务执行记录(6 阶段逐轮回填)。
